### PR TITLE
Schema validation integration and validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ java -jar yippee-ki-json.jar [--yippee.config=file] --yippee.action=action \
     [--yippee.excludes[0]=pattern] [--yippee.excludes[1]=pattern] ...\
     [--yippee.excludes[N]=pattern] [--yippee.allow-overwrite={true|false}]\
     [--yippee.relaxed-yml-schema=={true|false}] --yippee.output-directory=directory
+    [--yippee.charset=charset]
 ```
 
 #### Concept
@@ -99,6 +100,27 @@ exclusion: `exclude.json`.
 | `--yippee.excludes[0..N]`     | Input file exclude wildcard patterns.                                                |
 | `--yippee.output`             | Output file path.                                                                    |
 | `--yippee.output-directory`   | Output directory path.                                                               |
+| `--yippee.charset`            | Default character set used during parsing. Default: `UTF-8`                          |
+
+#### SchemaStore integration
+Prefix: `--additional.schema-store.<option>`
+
+| Option              | Description                                                                                           |
+| ------------------- | ----------------------------------------------------------------------------------------------------- |
+| `catalog-uri`       | The URI of the SchemaStore catalog JSON. Default: `https://www.schemastore.org/api/json/catalog.json` |
+| `schema-array-path` | The JSON Path we will use to get the list/array items of the catalog. Default: `$.schemas[*]`         |
+| `mapping-name-key`  | The key referencing the name of the schema item. Default: `name`                                      |
+| `mapping-url-key`   | The key referencing the URI of the schema item. Default: `url`                                        |
+
+#### HTTP Client
+Prefix: `--additional.http.<option>`
+
+| Option                | Description                                                                                     |
+| --------------------- | ----------------------------------------------------------------------------------------------- |
+| `user-agent`          | The value of the user-agent HTTP header.                                                        |
+| `add-default-headers` | Boolean telling the app to add the default HTTP headers automatically. Default: `true`          |
+| `min-success-status`  | The minimum (inclusive) HTTP status code value we should consider as successful. Default: `200` |
+| `max-success-status`  | The maximum (inclusive) HTTP status code value we should consider as successful. Default: `299` |
 
 ##### Spring Boot options
 All generic Spring Boot options are supported. Please find a few useful ones below.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ java -jar yippee-ki-json.jar [--yippee.config=file] --yippee.action=action \
     [--yippee.includes[1]=pattern] ... [--yippee.includes[N]=pattern] \
     [--yippee.excludes[0]=pattern] [--yippee.excludes[1]=pattern] ...\
     [--yippee.excludes[N]=pattern] [--yippee.allow-overwrite={true|false}]\
-     --yippee.output-directory=directory
+    [--yippee.relaxed-yml-schema=={true|false}] --yippee.output-directory=directory
 ```
 
 #### Concept
@@ -88,16 +88,17 @@ exclusion: `exclude.json`.
 
 #### Options
 ##### General options
-| Option                      | Description                                                                            |
-| --------------------------- | -------------------------------------------------------------------------------------- |
-| `--yippee.config`           | The path where the action descriptor can be located. Default: `actions.yml`            |
-| `--yippee.action`           | The name of the action we want to execute.                                             |
-| `--yippee.input`            | The name of the input file/directory. Default: `./`                                    |
-| `--yippee.allow-overwrite`  | Specifies whether we allow overwriting existing outputs. Default: `true`               |
-| `--yippee.includes[0..N]`   | Input file include wildcard patterns. Default: `*.json`                                |
-| `--yippee.excludes[0..N]`   | Input file exclude wildcard patterns.                                                  |
-| `--yippee.output`           | Output file path.                                                                      |
-| `--yippee.output-directory` | Output directory path.                                                                 |
+| Option                        | Description                                                                          |
+| ----------------------------- | ------------------------------------------------------------------------------------ |
+| `--yippee.config`             | The path where the action descriptor can be located. Default: `actions.yml`          |
+| `--yippee.action`             | The name of the action we want to execute.                                           |
+| `--yippee.input`              | The name of the input file/directory. Default: `./`                                  |
+| `--yippee.allow-overwrite`    | Specifies whether we allow overwriting existing outputs. Default: `true`             |
+| `--yippee.relaxed-yml-schema` | Allows suppression of YML configuration related schema violations. Default: `false`  |
+| `--yippee.includes[0..N]`     | Input file include wildcard patterns. Default: `*.json`                              |
+| `--yippee.excludes[0..N]`     | Input file exclude wildcard patterns.                                                |
+| `--yippee.output`             | Output file path.                                                                    |
+| `--yippee.output-directory`   | Output directory path.                                                               |
 
 ##### Spring Boot options
 All generic Spring Boot options are supported. Please find a few useful ones below.

--- a/build.gradle
+++ b/build.gradle
@@ -53,17 +53,22 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.jayway.jsonpath:json-path'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+    implementation 'com.networknt:json-schema-validator'
     implementation 'org.hibernate.validator:hibernate-validator'
     implementation 'org.glassfish:javax.el'
     implementation 'javax.el:javax.el-api'
     implementation 'commons-io:commons-io'
     implementation 'com.google.guava:guava'
     implementation 'org.jetbrains:annotations'
+    implementation 'javax.inject:javax.inject'
+    implementation 'ch.qos.logback:logback-classic'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+    testImplementation 'com.github.tomakehurst:wiremock'
 }
 
 dependencyManagement {
@@ -72,9 +77,17 @@ dependencyManagement {
             dependency 'javax.el:javax.el-api:3.0.0'
             dependency 'org.glassfish:javax.el:3.0.0'
             dependency 'com.jayway.jsonpath:json-path:2.4.0'
+            dependency 'com.networknt:json-schema-validator:1.0.40'
             dependency 'org.jetbrains:annotations:19.0.0'
+            dependency 'javax.inject:javax.inject:1'
             dependency 'commons-io:commons-io:2.6'
             dependency 'com.google.guava:guava:29.0-jre'
+        }
+    }
+
+    testImplementation {
+        dependencies {
+            dependency 'com.github.tomakehurst:wiremock:2.26.3'
         }
     }
 }
@@ -138,30 +151,56 @@ bootJar {
     archiveVersion.value(project.version as String)
 }
 
-task systemTestRun(type: Exec) {
+task systemTestRunConvert(type: Exec) {
     inputs.file(file(bootJar.outputs.files.singleFile))
-    inputs.file(file("./src/test/resources/json/example.json"))
-    inputs.file(file("./src/test/resources/yaml/example.yml"))
-    outputs.file(file("./build/test-results/systemTest/example.json"))
+    inputs.file(file("${buildDir}/resources/test/json/example.json"))
+    inputs.file(file("${buildDir}/resources/test/yaml/example.yml"))
+    outputs.file(file("${buildDir}/test-results/systemTest/example.json"))
     dependsOn bootJar
 
     group = "Execution"
     description = "Run the output executable jar with ExecTask"
     commandLine "java", "-jar", bootJar.outputs.files.singleFile,
-            "--yippee.config=./src/test/resources/yaml/example.yml",
-            "--yippee.input=./src/test/resources/json/example.json",
-            "--yippee.output=./build/test-results/systemTest/example.json",
+            "--yippee.config=${buildDir}/resources/test/yaml/example.yml",
+            "--yippee.input=${buildDir}/resources/test/json/example.json",
+            "--yippee.output=${buildDir}/test-results/systemTest/example.json",
             "--yippee.action=split-name"
     logging.captureStandardOutput LogLevel.INFO
     logging.captureStandardError LogLevel.ERROR
 }
+task systemTestRunValidate(type: Exec) {
+    inputs.file(file(bootJar.outputs.files.singleFile))
+    inputs.file(file("${buildDir}/resources/test/validation/validation-input.json"))
+    inputs.file(file("${buildDir}/resources/test/validation/test-schema.json"))
+    inputs.file(file("${buildDir}/resources/test/yaml/all-rules.yml"))
+    outputs.file(file("${buildDir}/test-results/systemTest/validation-output.json"))
+    dependsOn bootJar
+
+    group = "Execution"
+    description = "Run the output executable jar with ExecTask"
+    commandLine "java", "-jar", bootJar.outputs.files.singleFile,
+            "--yippee.config=${buildDir}/resources/test/yaml/all-rules.yml",
+            "--yippee.input=${buildDir}/resources/test/validation/validation-input.json",
+            "--yippee.output=${buildDir}/test-results/systemTest/validation-output.json",
+            "--yippee.action=validate"
+    logging.captureStandardOutput LogLevel.INFO
+    logging.captureStandardError LogLevel.ERROR
+}
 task systemTest {
-    dependsOn systemTestRun
-    inputs.file(file("./build/test-results/systemTest/example.json"))
-    inputs.file(file("./src/test/resources/json/example-split.json"))
+    dependsOn systemTestRunConvert
+    dependsOn systemTestRunValidate
+    inputs.file(file("${buildDir}/test-results/systemTest/example.json"))
+    inputs.file(file("${buildDir}/resources/test/json/example-split.json"))
+    inputs.file(file("${buildDir}/test-results/systemTest/validation-output.json"))
+    inputs.file(file("${buildDir}/resources/test/validation/validation-output.json"))
     doLast {
-        if (file("./build/test-results/systemTest/example.json").text != file("./src/test/resources/json/example-split.json").text) {
-            throw new StopExecutionException("System test assertion failed.")
+        if (file("${buildDir}/test-results/systemTest/example.json").text
+                != file("${buildDir}/resources/test/json/example-split.json").text) {
+            throw new StopExecutionException("System test (convert) assertion failed.")
+        }
+        if (file("${buildDir}/test-results/systemTest/validation-output.json").text
+                != file("${buildDir}/resources/test/validation/validation-output.json").text) {
+            throw new StopExecutionException("System test (validate) assertion failed.")
         }
     }
 }
@@ -174,10 +213,16 @@ tasks.withType(Checkstyle) {
     }
 }
 
+task includeSchema(type: Copy) {
+    from file("${projectDir}/schema/yippee-ki-json_config_schema.json")
+    into file("${buildDir}/resources/main")
+}
+
 processResources {
     filesMatching('application.properties') {
         expand(project.properties)
     }
+    finalizedBy includeSchema
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,9 @@ jacoco {
 }
 
 jacocoTestCoverageVerification {
+    inputs.file(file("${buildDir}/reports/jacoco/report.xml"))
+    outputs.file(file("${buildDir}/reports/jacoco/jacocoTestCoverageVerification"))
+
     violationRules {
         rule {
             limit {
@@ -141,6 +144,9 @@ jacocoTestCoverageVerification {
                     'com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper'
             ]
         }
+    }
+    doLast {
+        file("${buildDir}/reports/jacoco/jacocoTestCoverageVerification").write("Passed")
     }
 }
 bootJar.dependsOn check
@@ -193,6 +199,7 @@ task systemTest {
     inputs.file(file("${buildDir}/resources/test/json/example-split.json"))
     inputs.file(file("${buildDir}/test-results/systemTest/validation-output.json"))
     inputs.file(file("${buildDir}/resources/test/validation/validation-output.json"))
+    outputs.file(file("${buildDir}/test-results/systemTest/result"))
     doLast {
         if (file("${buildDir}/test-results/systemTest/example.json").text
                 != file("${buildDir}/resources/test/json/example-split.json").text) {
@@ -202,6 +209,7 @@ task systemTest {
                 != file("${buildDir}/resources/test/validation/validation-output.json").text) {
             throw new StopExecutionException("System test (validate) assertion failed.")
         }
+        file("${buildDir}/test-results/systemTest/result").write("Passed")
     }
 }
 

--- a/schema/yippee-ki-json_config_schema.json
+++ b/schema/yippee-ki-json_config_schema.json
@@ -8,12 +8,12 @@
         "name": {
           "$comment": "A single JSON key name",
           "type": "string",
-          "pattern": "^[a-zA-Z]+[a-zA-Z0-9\\-_]*$"
+          "pattern": "^[$_a-zA-Z]+[$a-zA-Z0-9\\-_]*$"
         },
         "jsonPath": {
           "$comment": "https://github.com/json-path/JsonPath",
           "type": "string",
-          "pattern": "^[$@](((\\.|\\.\\.)([a-zA-Z]+[a-zA-Z0-9\\-_]*|\\*))|\\[\\*]|\\[[0-9]+((, [0-9]+)*|:[0-9]+)]|\\['[a-zA-Z]+[a-zA-Z0-9\\-_]*'(, '[a-zA-Z]+[a-zA-Z0-9\\-_]*')*]|\\[\\?\\(.+\\)])*$",
+          "pattern": "^[$@](((\\.|\\.\\.)([$_a-zA-Z]+[$a-zA-Z0-9\\-_]*|\\*))|\\[\\*]|\\[[0-9]+((, [0-9]+)*|:[0-9]+)]|\\['[$_a-zA-Z]+[$a-zA-Z0-9\\-_]*'(, '[$_a-zA-Z]+[$a-zA-Z0-9\\-_]*')*]|\\[\\?\\(.+\\)])*$",
           "description": "A JSON Path selecting one or more nodes of the parsed JSON document."
         },
         "chronoUnit": {
@@ -35,6 +35,33 @@
             "MILLENIA"
           ],
           "description": "The chrono unit we want to use."
+        },
+        "charSet": {
+          "type": "string",
+          "enum": [
+            "UTF-8",
+            "UTF-16",
+            "UTF-16LE",
+            "UTF-16BE",
+            "ISO-8859-1",
+            "US-ASCII"
+          ],
+          "description": "Standard character sets."
+        },
+        "httpMethod": {
+          "type": "string",
+          "enum": [
+            "GET",
+            "POST"
+          ],
+          "description": "Supported HTTP methods."
+        },
+        "httpHeaders": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "uniqueItems": true
         }
       }
     },
@@ -230,6 +257,85 @@
           ],
           "additionalProperties": false
         },
+        "functionHttpResourceByUri": {
+          "type": "object",
+          "$comment": "https://github.com/nagyesta/yippee-ki-json/wiki/Built-in-functions#http-resource-by-uri-function",
+          "properties": {
+            "name": {
+              "type": "string",
+              "const": "httpResourceByUri",
+              "description": "The name of the function."
+            },
+            "uriFunction": {
+              "$ref": "#/definitions/functionTypes/definitions/anyFunction"
+            },
+            "uri": {
+              "type": "string",
+              "description": "The default value of the URI we want to use."
+            },
+            "httpMethod": {
+              "$ref": "#/definitions/commonTypes/definitions/httpMethod"
+            },
+            "httpHeaders": {
+              "$ref": "#/definitions/commonTypes/definitions/httpHeaders"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "minProperties": 2,
+          "additionalProperties": false
+        },
+        "functionHttpResource": {
+          "type": "object",
+          "$comment": "https://github.com/nagyesta/yippee-ki-json/wiki/Built-in-functions#http-resource-function",
+          "properties": {
+            "name": {
+              "type": "string",
+              "const": "httpResource",
+              "description": "The name of the function."
+            },
+            "uriFunction": {
+              "$ref": "#/definitions/functionTypes/definitions/anyFunction"
+            },
+            "methodFunction": {
+              "$ref": "#/definitions/functionTypes/definitions/anyFunction"
+            },
+            "headerFunction": {
+              "$ref": "#/definitions/functionTypes/definitions/anyFunction"
+            },
+            "uri": {
+              "type": "string",
+              "description": "The default value of the URI we want to use."
+            },
+            "httpMethod": {
+              "$ref": "#/definitions/commonTypes/definitions/httpMethod"
+            },
+            "httpHeaders": {
+              "$ref": "#/definitions/commonTypes/definitions/httpHeaders"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "minProperties": 2,
+          "additionalProperties": false
+        },
+        "functionJsonParse": {
+          "type": "object",
+          "$comment": "https://github.com/nagyesta/yippee-ki-json/wiki/Built-in-functions#ljson-parse-function",
+          "properties": {
+            "name": {
+              "type": "string",
+              "const": "jsonParse",
+              "description": "The name of the function."
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "additionalProperties": false
+        },
         "functionReplace": {
           "type": "object",
           "$comment": "https://github.com/nagyesta/yippee-ki-json/wiki/Built-in-functions#literal-replace-function",
@@ -326,6 +432,9 @@
                     "multiply",
                     "subtract",
                     "epochMillisDateAdd",
+                    "httpResourceByUri",
+                    "httpResource",
+                    "jsonParse",
                     "replace",
                     "regex",
                     "stringDateAdd"
@@ -425,6 +534,42 @@
               "if": {
                 "properties": {
                   "name": {
+                    "const": "httpResourceByUri"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "#/definitions/functionTypes/definitions/functionHttpResourceByUri"
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "name": {
+                    "const": "httpResource"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "#/definitions/functionTypes/definitions/functionHttpResource"
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "name": {
+                    "const": "jsonParse"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "#/definitions/functionTypes/definitions/functionJsonParse"
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "name": {
                     "const": "replace"
                   }
                 }
@@ -504,6 +649,119 @@
           ],
           "additionalProperties": false
         },
+        "supplierFile": {
+          "type": "object",
+          "$comment": "https://github.com/nagyesta/yippee-ki-json/wiki/Built-in-suppliers#file-content-supplier",
+          "properties": {
+            "name": {
+              "type": "string",
+              "const": "file",
+              "description": "The name of the supplier."
+            },
+            "path": {
+              "type": "string",
+              "description": "The file path where the source file can be found."
+            },
+            "charset": {
+              "$ref": "#/definitions/commonTypes/definitions/charSet"
+            }
+          },
+          "required": [
+            "name",
+            "path"
+          ],
+          "additionalProperties": false
+        },
+        "supplierHttpResource": {
+          "type": "object",
+          "$comment": "https://github.com/nagyesta/yippee-ki-json/wiki/Built-in-suppliers#http-resource-supplier",
+          "properties": {
+            "name": {
+              "type": "string",
+              "const": "httpResource",
+              "description": "The name of the supplier."
+            },
+            "uri": {
+              "type": "string",
+              "description": "The URI where the content is located."
+            },
+            "httpHeaders": {
+              "$ref": "#/definitions/commonTypes/definitions/httpHeaders"
+            },
+            "httpMethod": {
+              "$ref": "#/definitions/commonTypes/definitions/httpMethod"
+            },
+            "charset": {
+              "$ref": "#/definitions/commonTypes/definitions/charSet"
+            }
+          },
+          "required": [
+            "name",
+            "uri"
+          ],
+          "additionalProperties": false
+        },
+        "supplierJsonSchema": {
+          "type": "object",
+          "$comment": "https://github.com/nagyesta/yippee-ki-json/wiki/Built-in-suppliers#json-schema-supplier",
+          "properties": {
+            "name": {
+              "type": "string",
+              "const": "jsonSchema",
+              "description": "The name of the supplier."
+            },
+            "source": {
+              "$ref": "#/definitions/supplierTypes/definitions/anySupplier"
+            }
+          },
+          "required": [
+            "name",
+            "source"
+          ],
+          "additionalProperties": false
+        },
+        "supplierSchemaStore": {
+          "type": "object",
+          "$comment": "https://github.com/nagyesta/yippee-ki-json/wiki/Built-in-suppliers#json-schemastore-schema-supplier",
+          "properties": {
+            "name": {
+              "type": "string",
+              "const": "schemaStore",
+              "description": "The name of the supplier."
+            },
+            "schemaName": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "schemaName"
+          ],
+          "additionalProperties": false
+        },
+        "supplierConverting": {
+          "type": "object",
+          "$comment": "https://github.com/nagyesta/yippee-ki-json/wiki/Built-in-suppliers#converting-supplier",
+          "properties": {
+            "name": {
+              "type": "string",
+              "const": "converting",
+              "description": "The name of the supplier."
+            },
+            "stringSource": {
+              "$ref": "#/definitions/supplierTypes/definitions/anySupplier"
+            },
+            "converter": {
+              "$ref": "#/definitions/functionTypes/definitions/anyFunction"
+            }
+          },
+          "required": [
+            "name",
+            "stringSource",
+            "converter"
+          ],
+          "additionalProperties": false
+        },
         "anySupplier": {
           "allOf": [
             {
@@ -512,6 +770,11 @@
                 "name": {
                   "type": "string",
                   "enum": [
+                    "converting",
+                    "httpResource",
+                    "jsonSchema",
+                    "file",
+                    "schemaStore",
                     "staticString",
                     "staticJson"
                   ]
@@ -520,6 +783,66 @@
               "required": [
                 "name"
               ]
+            },
+            {
+              "if": {
+                "properties": {
+                  "name": {
+                    "const": "converting"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "#/definitions/supplierTypes/definitions/supplierConverting"
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "name": {
+                    "const": "httpResource"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "#/definitions/supplierTypes/definitions/supplierHttpResource"
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "name": {
+                    "const": "jsonSchema"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "#/definitions/supplierTypes/definitions/supplierJsonSchema"
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "name": {
+                    "const": "file"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "#/definitions/supplierTypes/definitions/supplierFile"
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "name": {
+                    "const": "schemaStore"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "#/definitions/supplierTypes/definitions/supplierSchemaStore"
+              }
             },
             {
               "if": {
@@ -653,7 +976,7 @@
             },
             "childPath": {
               "type": "string",
-              "pattern": "^([a-zA-Z]+[a-zA-Z0-9\\-_]+)(.[a-zA-Z]+[a-zA-Z0-9\\-_]+)*$",
+              "pattern": "^([$_a-zA-Z]+[$a-zA-Z0-9\\-_]+)(.[$_a-zA-Z]+[$a-zA-Z0-9\\-_]+)*$",
               "description": "The path (relative to the rule's JSON Path) in a dotted format."
             },
             "predicate": {
@@ -1307,6 +1630,74 @@
           ],
           "additionalProperties": false
         },
+        "ruleValidate": {
+          "$comment": "https://github.com/nagyesta/yippee-ki-json/wiki/Built-in-rules#validate",
+          "properties": {
+            "name": {
+              "type": "string",
+              "const": "validate"
+            },
+            "path": {
+              "type": "string",
+              "const": "$",
+              "description": "Must be the root JSON Path as the validator cannot work on sub-schema."
+            },
+            "params": {
+              "type": "object",
+              "properties": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/supplierTypes/definitions/anySupplier"
+                    },
+                    {
+                      "description": "The supplier which will supply the JSON Schema used for the validation."
+                    }
+                  ]
+                },
+                "onFailure": {
+                  "properties": {
+                    "transformation": {
+                      "type": "string",
+                      "enum": [
+                        "ABORT",
+                        "SKIP_REST",
+                        "CONTINUE"
+                      ],
+                      "description": "Defines what to do with the rule chain in case of failure."
+                    },
+                    "violation": {
+                      "type": "string",
+                      "enum": [
+                        "LOG_ONLY",
+                        "COMMENT_JSON",
+                        "IGNORE"
+                      ],
+                      "description": "Defines what to do with the violations found (how to report them)."
+                    }
+                  },
+                  "required": [
+                    "transformation",
+                    "violation"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "description": "Defines behavior which will be used in case of validation failure.",
+              "required": [
+                "onFailure",
+                "schema"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "name",
+            "path",
+            "params"
+          ],
+          "additionalProperties": false
+        },
         "anyRule": {
           "allOf": [
             {
@@ -1322,7 +1713,8 @@
                     "delete",
                     "rename",
                     "replaceMap",
-                    "replace"
+                    "replace",
+                    "validate"
                   ],
                   "description": "The name of the rule."
                 },
@@ -1434,6 +1826,18 @@
               },
               "then": {
                 "$ref": "#/definitions/ruleTypes/definitions/ruleReplace"
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "name": {
+                    "const": "validate"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "#/definitions/ruleTypes/definitions/ruleValidate"
               }
             }
           ]

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/annotation/EmbedParam.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/annotation/EmbedParam.java
@@ -1,0 +1,39 @@
+package com.github.nagyesta.yippeekijson.core.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Describes a parameter of a constructor allowing use structured data with the
+ * intent of using this param for a FunctionRegistry lookup.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+public @interface EmbedParam {
+
+    /**
+     * Allows explicit definition of the names we need to lookup.
+     * If absent, the evaluation will fall back to:
+     * <ol>
+     *     <li>{@link org.springframework.beans.factory.annotation.Qualifier#value()}</li>
+     *     <li>{@link javax.inject.Named#value()}</li>
+     *     <li>{@link java.lang.reflect.Parameter#getName()}</li>
+     * </ol>
+     *
+     * @return the preferred name of the parameter.
+     */
+    String value() default "";
+
+    /**
+     * Allows us to identify if null values are accepted by the parameter.
+     * The evaluation will also respect the presence of the following
+     * annotations if false.
+     * <ul>
+     *     <li>{@link javax.annotation.Nullable}</li>
+     *     <li>{@link org.springframework.lang.Nullable}</li>
+     * </ul>
+     *
+     * @return true if the value can be null despite not being annotates as such.
+     */
+    boolean nullable() default false;
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/annotation/Injectable.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/annotation/Injectable.java
@@ -1,0 +1,20 @@
+package com.github.nagyesta.yippeekijson.core.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks a class used for a Spring bean to allow injection of the bean in question into
+ * rules / functions / suppliers / predicates.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface Injectable {
+
+    /**
+     * Defines which is the type we can look for when we are instantiating the objects.
+     *
+     * @return the type we want to use.
+     */
+    Class<?> forType();
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/annotation/MapParam.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/annotation/MapParam.java
@@ -1,0 +1,39 @@
+package com.github.nagyesta.yippeekijson.core.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Describes a parameter of a constructor allowing use structured data as a
+ * {@link String} {@link java.util.Map}.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+public @interface MapParam {
+
+    /**
+     * Allows explicit definition of the names we need to lookup.
+     * If absent, the evaluation will fall back to:
+     * <ol>
+     *     <li>{@link org.springframework.beans.factory.annotation.Qualifier#value()}</li>
+     *     <li>{@link javax.inject.Named#value()}</li>
+     *     <li>{@link java.lang.reflect.Parameter#getName()}</li>
+     * </ol>
+     *
+     * @return the preferred name of the parameter.
+     */
+    String value() default "";
+
+    /**
+     * Allows us to identify if null values are accepted by the parameter.
+     * The evaluation will also respect the presence of the following
+     * annotations if false.
+     * <ul>
+     *     <li>{@link javax.annotation.Nullable}</li>
+     *     <li>{@link org.springframework.lang.Nullable}</li>
+     * </ul>
+     *
+     * @return true if the value can be null despite not being annotates as such.
+     */
+    boolean nullable() default false;
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/annotation/MethodParam.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/annotation/MethodParam.java
@@ -4,10 +4,13 @@ import java.lang.annotation.*;
 
 /**
  * Describes a parameter of a Method/Constructor to help processing externalized configuration.
+ *
+ * @deprecated use any of {@link ValueParam}, {@link MapParam} or {@link EmbedParam}.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.PARAMETER)
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Deprecated
 public @interface MethodParam {
 
     /**
@@ -41,4 +44,11 @@ public @interface MethodParam {
      * @return true if raw format is needed for the map.
      */
     boolean paramMap() default false;
+
+    /**
+     * Tells the converter that the parameter can be missing and replaced with null.
+     *
+     * @return true if raw parameter can be missing and replaced wit null.
+     */
+    boolean nullable() default false;
 }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/annotation/ValueParam.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/annotation/ValueParam.java
@@ -1,0 +1,38 @@
+package com.github.nagyesta.yippeekijson.core.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Describes a parameter of a constructor allowing use {@link String} data.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+public @interface ValueParam {
+
+    /**
+     * Allows explicit definition of the names we need to lookup.
+     * If absent, the evaluation will fall back to:
+     * <ol>
+     *     <li>{@link org.springframework.beans.factory.annotation.Qualifier#value()}</li>
+     *     <li>{@link javax.inject.Named#value()}</li>
+     *     <li>{@link java.lang.reflect.Parameter#getName()}</li>
+     * </ol>
+     *
+     * @return the preferred name of the parameter.
+     */
+    String value() default "";
+
+    /**
+     * Allows us to identify if null values are accepted by the parameter.
+     * The evaluation will also respect the presence of the following
+     * annotations if false.
+     * <ul>
+     *     <li>{@link javax.annotation.Nullable}</li>
+     *     <li>{@link org.springframework.lang.Nullable}</li>
+     * </ul>
+     *
+     * @return true if the value can be null despite not being annotates as such.
+     */
+    boolean nullable() default false;
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/entities/AdditionalConfig.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/entities/AdditionalConfig.java
@@ -1,0 +1,17 @@
+package com.github.nagyesta.yippeekijson.core.config.entities;
+
+import com.github.nagyesta.yippeekijson.core.annotation.Injectable;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Injectable(forType = AdditionalConfig.class)
+@Configuration
+@ConfigurationProperties(prefix = "additional", ignoreUnknownFields = false)
+public class AdditionalConfig {
+    private SchemaStoreConfig schemaStore;
+    private HttpConfig http;
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/entities/HttpConfig.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/entities/HttpConfig.java
@@ -1,0 +1,75 @@
+package com.github.nagyesta.yippeekijson.core.config.entities;
+
+import com.github.nagyesta.yippeekijson.core.annotation.Injectable;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Injectable(forType = HttpConfig.class)
+@Configuration
+public class HttpConfig {
+    private String userAgent;
+    private boolean addDefaultHeaders;
+    private int minSuccessStatus;
+    private int maxSuccessStatus;
+    private int timeoutSeconds;
+
+    public HttpConfig() {
+    }
+
+    private HttpConfig(final HttpConfigBuilder builder) {
+        this.userAgent = builder.userAgent;
+        this.addDefaultHeaders = builder.addDefaultHeaders;
+        this.minSuccessStatus = builder.minSuccessStatus;
+        this.maxSuccessStatus = builder.maxSuccessStatus;
+        this.timeoutSeconds = builder.timeoutSeconds;
+    }
+
+    public static HttpConfigBuilder builder() {
+        return new HttpConfigBuilder();
+    }
+
+    @SuppressWarnings({"UnusedReturnValue", "checkstyle:HiddenField", "checkstyle:DesignForExtension"})
+    public static class HttpConfigBuilder {
+        private String userAgent;
+        private boolean addDefaultHeaders;
+        private int minSuccessStatus;
+        private int maxSuccessStatus;
+        private int timeoutSeconds;
+
+        HttpConfigBuilder() {
+        }
+
+        public HttpConfigBuilder userAgent(final String userAgent) {
+            this.userAgent = userAgent;
+            return this;
+        }
+
+        public HttpConfigBuilder addDefaultHeaders(final boolean addDefaultHeaders) {
+            this.addDefaultHeaders = addDefaultHeaders;
+            return this;
+        }
+
+        public HttpConfigBuilder minSuccessStatus(final int minSuccessStatus) {
+            this.minSuccessStatus = minSuccessStatus;
+            return this;
+        }
+
+        public HttpConfigBuilder maxSuccessStatus(final int maxSuccessStatus) {
+            this.maxSuccessStatus = maxSuccessStatus;
+            return this;
+        }
+
+        public HttpConfigBuilder timeoutSeconds(final int timeoutSeconds) {
+            this.timeoutSeconds = timeoutSeconds;
+            return this;
+        }
+
+        public HttpConfig build() {
+            return new HttpConfig(this);
+        }
+
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/entities/RunConfig.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/entities/RunConfig.java
@@ -1,5 +1,6 @@
 package com.github.nagyesta.yippeekijson.core.config.entities;
 
+import com.github.nagyesta.yippeekijson.core.annotation.Injectable;
 import com.github.nagyesta.yippeekijson.core.config.validation.ValidYippeeConfig;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,6 +14,8 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.io.File;
 import java.io.FileFilter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -20,6 +23,7 @@ import java.util.Optional;
 @Getter
 @Setter
 @ValidYippeeConfig
+@Injectable(forType = RunConfig.class)
 @Configuration
 @ConfigurationProperties(prefix = "yippee", ignoreUnknownFields = false)
 public class RunConfig {
@@ -33,6 +37,9 @@ public class RunConfig {
     private String output;
     private String outputDirectory;
     private boolean allowOverwrite;
+    private boolean relaxedYmlSchema;
+    @NotNull
+    private Charset charset = StandardCharsets.UTF_8;
     @NotNull
     @Size(min = 1)
     private List<String> includes;
@@ -49,6 +56,8 @@ public class RunConfig {
         this.output = builder.output;
         this.outputDirectory = builder.outputDirectory;
         this.allowOverwrite = builder.allowOverwrite;
+        this.relaxedYmlSchema = builder.relaxedYmlSchema;
+        this.charset = builder.charset;
         this.includes = builder.includes;
         this.excludes = builder.excludes;
     }
@@ -130,6 +139,8 @@ public class RunConfig {
         private String output;
         private String outputDirectory;
         private boolean allowOverwrite;
+        private boolean relaxedYmlSchema;
+        private Charset charset = StandardCharsets.UTF_8;
         private List<String> includes = Collections.emptyList();
         private List<String> excludes = Collections.emptyList();
 
@@ -166,6 +177,16 @@ public class RunConfig {
             return this;
         }
 
+        public RunConfigBuilder relaxedYmlSchema(final boolean relaxedYmlSchema) {
+            this.relaxedYmlSchema = relaxedYmlSchema;
+            return this;
+        }
+
+        public RunConfigBuilder charset(final Charset charset) {
+            this.charset = charset;
+            return this;
+        }
+
         public RunConfigBuilder includes(final List<String> includes) {
             this.includes = includes;
             return this;
@@ -178,17 +199,6 @@ public class RunConfig {
 
         public RunConfig build() {
             return new RunConfig(this);
-        }
-
-        @Override
-        public String toString() {
-            return "RunConfig.RunConfigBuilder(config=" + this.config
-                    + ", action=" + this.action
-                    + ", input=" + this.input
-                    + ", output=" + this.output
-                    + ", outputDirectory=" + this.outputDirectory
-                    + ", allowOverwrite=" + this.allowOverwrite
-                    + ", includes=" + this.includes + ", excludes=" + this.excludes + ")";
         }
     }
 }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/entities/RunConfig.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/entities/RunConfig.java
@@ -39,7 +39,7 @@ public class RunConfig {
     private boolean allowOverwrite;
     private boolean relaxedYmlSchema;
     @NotNull
-    private Charset charset = StandardCharsets.UTF_8;
+    private Charset charset;
     @NotNull
     @Size(min = 1)
     private List<String> includes;

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/entities/SchemaStoreConfig.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/entities/SchemaStoreConfig.java
@@ -1,0 +1,66 @@
+package com.github.nagyesta.yippeekijson.core.config.entities;
+
+import com.github.nagyesta.yippeekijson.core.annotation.Injectable;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Injectable(forType = SchemaStoreConfig.class)
+@Configuration
+public class SchemaStoreConfig {
+    private String catalogUri;
+    private String mappingNameKey;
+    private String mappingUrlKey;
+    private String schemaArrayPath;
+
+    public SchemaStoreConfig() {
+    }
+
+    private SchemaStoreConfig(final SchemaStoreConfigBuilder builder) {
+        this.catalogUri = builder.catalogUri;
+        this.mappingNameKey = builder.mappingNameKey;
+        this.mappingUrlKey = builder.mappingUrlKey;
+        this.schemaArrayPath = builder.schemaArrayPath;
+    }
+
+    public static SchemaStoreConfigBuilder builder() {
+        return new SchemaStoreConfigBuilder();
+    }
+
+    @SuppressWarnings({"UnusedReturnValue", "checkstyle:HiddenField", "checkstyle:DesignForExtension"})
+    public static class SchemaStoreConfigBuilder {
+        private String catalogUri;
+        private String mappingNameKey;
+        private String mappingUrlKey;
+        private String schemaArrayPath;
+
+        SchemaStoreConfigBuilder() {
+        }
+
+        public SchemaStoreConfigBuilder catalogUri(final String catalogUri) {
+            this.catalogUri = catalogUri;
+            return this;
+        }
+
+        public SchemaStoreConfigBuilder mappingNameKey(final String mappingNameKey) {
+            this.mappingNameKey = mappingNameKey;
+            return this;
+        }
+
+        public SchemaStoreConfigBuilder schemaArrayPath(final String schemaArrayPath) {
+            this.schemaArrayPath = schemaArrayPath;
+            return this;
+        }
+
+        public SchemaStoreConfigBuilder mappingUrlKey(final String mappingUrlKey) {
+            this.mappingUrlKey = mappingUrlKey;
+            return this;
+        }
+
+        public SchemaStoreConfig build() {
+            return new SchemaStoreConfig(this);
+        }
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/ActionConfigParser.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/ActionConfigParser.java
@@ -15,18 +15,20 @@ public interface ActionConfigParser {
      * Does the parsing from a stream.
      *
      * @param stream The source of the configuration we need to parse.
+     * @param relaxed Turns off the strict schema validation
      * @return The parsed configuration.
      * @throws ConfigParseException When the parsing fails for some reason.
      * @implNote The stream will only be read but not closed. The caller, who opened the {@link InputStream} must make sure to close it.
      */
-    JsonActions parse(InputStream stream) throws ConfigParseException;
+    JsonActions parse(InputStream stream, boolean relaxed) throws ConfigParseException;
 
     /**
      * Does the parsing from a file.
      *
      * @param config The source file containing the configuration we need to parse.
+     * @param relaxed Turns off the strict schema validation
      * @return The parsed configuration.
      * @throws ConfigParseException When the parsing fails for some reason.
      */
-    JsonActions parse(File config) throws ConfigParseException;
+    JsonActions parse(File config, boolean relaxed) throws ConfigParseException;
 }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/FunctionRegistry.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/FunctionRegistry.java
@@ -3,6 +3,10 @@ package com.github.nagyesta.yippeekijson.core.config.parser;
 import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
 import lombok.NonNull;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -12,7 +16,7 @@ import java.util.function.Supplier;
 /**
  * Registry for named {@link Function}, {@link Supplier}, {@link Predicate} implementations to be used during the parsing.
  */
-public interface FunctionRegistry {
+public interface FunctionRegistry extends InitializingBean, ApplicationContextAware {
 
     /**
      * Finds a {@link Supplier} based on the provided input parameters.
@@ -42,11 +46,20 @@ public interface FunctionRegistry {
     @NotNull Predicate<Object> lookupPredicate(Map<String, RawConfigParam> map);
 
     /**
-     * Returns a {@link JsonMapper} implementation for object mapping.
+     * Finds a {@link Predicate} based on the provided input parameters or returns the provided default value if the map is empty.
      *
-     * @return a mapper
+     * @param map          The input parameters.
+     * @param defaultValue The default value in case the map was empty.
+     * @return The configured {@link Predicate}
      */
-    JsonMapper jsonMapper();
+    @NotNull
+    default Predicate<Object> lookupPredicate(final Map<String, RawConfigParam> map, final Predicate<Object> defaultValue) {
+        if (CollectionUtils.isEmpty(map)) {
+            Assert.notNull(defaultValue, "Default value cannot be null.");
+            return defaultValue;
+        }
+        return lookupPredicate(map);
+    }
 
     /**
      * Registers a {@link Supplier} implementation annotated with @{@link com.github.nagyesta.yippeekijson.core.annotation.NamedSupplier}.

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/JsonMapper.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/JsonMapper.java
@@ -1,8 +1,10 @@
 package com.github.nagyesta.yippeekijson.core.config.parser;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.TypeRef;
 import lombok.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
@@ -16,9 +18,7 @@ public interface JsonMapper {
      *
      * @return the parser config
      */
-    default Configuration parserConfiguration() {
-        return Configuration.defaultConfiguration();
-    }
+    Configuration parserConfiguration();
 
     /**
      * Converts and input object to the desired format if possible.
@@ -29,6 +29,14 @@ public interface JsonMapper {
      * @return the converted object
      */
     <T> T mapTo(@NonNull Object input, @NonNull TypeRef<T> typeRef);
+
+    /**
+     * Returns an ObjectMapper with the same configuration we use for parsing/mapping.
+     *
+     * @return objectMapper
+     */
+    @NotNull
+    ObjectMapper objectMapper();
 
     /**
      * {@link TypeRef} implementation for {@link String} to {@link Object} {@link Map} type.

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/JsonRuleRegistry.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/JsonRuleRegistry.java
@@ -3,11 +3,13 @@ package com.github.nagyesta.yippeekijson.core.config.parser;
 import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawJsonRule;
 import com.github.nagyesta.yippeekijson.core.rule.JsonRule;
 import lombok.NonNull;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContextAware;
 
 /**
  * Registry for the known {@link JsonRule} implementations we will be able to parse.
  */
-public interface JsonRuleRegistry {
+public interface JsonRuleRegistry extends InitializingBean, ApplicationContextAware {
 
     /**
      * Attempts to find a previously registered rule class by name and instantiates it.

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/InjectableBeanSupport.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/InjectableBeanSupport.java
@@ -1,0 +1,120 @@
+package com.github.nagyesta.yippeekijson.core.config.parser.impl;
+
+import com.github.nagyesta.yippeekijson.core.annotation.Injectable;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+import javax.inject.Named;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public abstract class InjectableBeanSupport implements ApplicationContextAware, InitializingBean {
+
+    private final Map<Class<?>, Map<String, Object>> injectableBeans = new HashMap<>();
+    private final Logger log;
+    private ApplicationContext applicationContext;
+
+    protected InjectableBeanSupport(final Logger log) {
+        this.log = log;
+    }
+
+    /**
+     * Returns a valid candidate for injection.
+     *
+     * @param constructor The constructor we need to call
+     * @param parameter   The parameter we want to inject to
+     * @return An injectable bean if the parameter type allows
+     */
+    protected Object validCandidateOf(@NotNull final Constructor<?> constructor, @NotNull final Parameter parameter) {
+        final String parameterName = parameter.getName();
+        Assert.isTrue(this.injectableBeans.containsKey(parameter.getType()),
+                "Parameter " + constructor.getDeclaringClass().getSimpleName() + "."
+                        + parameterName + " is neither annotated with a param annotation nor is having an @Injectable type.");
+        Map<String, Object> candidates = injectableBeans.get(parameter.getType());
+        return primaryCandidate(candidates, constructor, parameter);
+    }
+
+    /**
+     * Returns true if the type provided has at least one registered bean candidate.
+     *
+     * @param type The parameter type we need to inject to
+     * @return true is suitable candidate exists
+     */
+    protected boolean hasCandidateFor(@NotNull final Class<?> type) {
+        return this.injectableBeans.containsKey(type);
+    }
+
+    private Object primaryCandidate(@NotNull final Map<String, Object> candidates,
+                                    @NotNull final Constructor<?> constructor,
+                                    @NotNull final Parameter parameter) {
+        if (candidates.size() == 1) {
+            return singleCandidate(candidates);
+        } else {
+            return candidateByName(candidates, constructor, parameter);
+        }
+    }
+
+    private Object candidateByName(@NotNull final Map<String, Object> candidates,
+                                   @NotNull final Constructor<?> constructor,
+                                   @NotNull final Parameter parameter) {
+        String name = parameter.getName();
+        if (parameter.isAnnotationPresent(Qualifier.class)) {
+            name = Objects.requireNonNullElse(StringUtils.trimToNull(parameter.getAnnotation(Qualifier.class).value()), name);
+        } else if (parameter.isAnnotationPresent(Named.class)) {
+            name = Objects.requireNonNullElse(StringUtils.trimToNull(parameter.getAnnotation(Named.class).value()), name);
+        }
+        final String parameterReference = constructor.getDeclaringClass().getSimpleName() + "."
+                + name;
+        Assert.isTrue(candidates.containsKey(name),
+                "Parameter " + parameterReference + " defined an unknown bean name: " + name + ".\n"
+                        + "Known names are: " + candidates.keySet());
+        return candidates.get(name);
+    }
+
+    @NotNull
+    private Object singleCandidate(@NotNull final Map<String, Object> candidates) {
+        return candidates.values().stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Single entity is not found."));
+    }
+
+    /**
+     * Will be called at the very last line of {@link #afterPropertiesSet()}.
+     */
+    protected abstract void afterInitialized();
+
+    @Override
+    public void setApplicationContext(final @NotNull ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    @SuppressWarnings("RedundantThrows")
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        log.info("Registering injectable beans.");
+        this.applicationContext.getBeansWithAnnotation(Injectable.class)
+                .forEach((name, bean) -> {
+                    Class<?> beanClass = ClassUtils.getUserClass(bean);
+                    log.debug("Processing: " + beanClass.getName());
+                    Assert.isTrue(beanClass.isAnnotationPresent(Injectable.class),
+                            "Bean class is supposed to be annotated: " + beanClass.getName());
+                    Class<?> forType = beanClass.getAnnotation(Injectable.class).forType();
+                    final Map<String, Object> map = this.injectableBeans.getOrDefault(forType, new HashMap<>());
+                    log.debug("Put " + name + " - " + forType.getName());
+                    map.put(name, bean);
+                    this.injectableBeans.put(forType, map);
+                });
+        this.afterInitialized();
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/JsonMapperImpl.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/JsonMapperImpl.java
@@ -1,6 +1,7 @@
 package com.github.nagyesta.yippeekijson.core.config.parser.impl;
 
 import com.fasterxml.jackson.databind.*;
+import com.github.nagyesta.yippeekijson.core.annotation.Injectable;
 import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.TypeRef;
@@ -9,6 +10,7 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import lombok.NonNull;
 import org.jetbrains.annotations.NotNull;
 
+@Injectable(forType = JsonMapper.class)
 public class JsonMapperImpl implements JsonMapper {
 
     @Override
@@ -24,18 +26,9 @@ public class JsonMapperImpl implements JsonMapper {
         return mappingProvider().map(input, typeRef, parserConfiguration());
     }
 
+    @Override
     @NotNull
-    private JacksonMappingProvider mappingProvider() {
-        return new JacksonMappingProvider(objectMapper());
-    }
-
-    @NotNull
-    private JacksonJsonProvider jsonProvider() {
-        return new JacksonJsonProvider(objectMapper());
-    }
-
-    @NotNull
-    private ObjectMapper objectMapper() {
+    public ObjectMapper objectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
         final SerializationConfig serializationConfig = objectMapper.getSerializationConfig()
                 .withoutFeatures(SerializationFeature.FAIL_ON_EMPTY_BEANS);
@@ -45,5 +38,15 @@ public class JsonMapperImpl implements JsonMapper {
                 .with(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS);
         objectMapper.setConfig(deserializationConfig);
         return objectMapper;
+    }
+
+    @NotNull
+    private JacksonMappingProvider mappingProvider() {
+        return new JacksonMappingProvider(objectMapper());
+    }
+
+    @NotNull
+    private JacksonJsonProvider jsonProvider() {
+        return new JacksonJsonProvider(objectMapper());
     }
 }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/ParameterContext.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/ParameterContext.java
@@ -1,0 +1,169 @@
+package com.github.nagyesta.yippeekijson.core.config.parser.impl;
+
+import com.github.nagyesta.yippeekijson.core.annotation.EmbedParam;
+import com.github.nagyesta.yippeekijson.core.annotation.MapParam;
+import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.util.Assert;
+
+import javax.inject.Named;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Parameter;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Contains all information about a parameter needed for instantiation.
+ */
+@Getter
+@ToString
+public final class ParameterContext {
+
+    private final String name;
+    private final boolean nullable;
+    private final boolean collectionTyped;
+    private final UseCase useCase;
+
+    private ParameterContext(final UseCase useCase, final String name, final boolean nullable, final boolean collectionTyped) {
+        this.useCase = useCase;
+        this.name = name;
+        this.nullable = nullable;
+        this.collectionTyped = collectionTyped;
+    }
+
+    @SuppressWarnings("deprecation")
+    public static ParameterContext forParameter(@NotNull final Parameter parameter) {
+        ParameterContext result;
+        if (parameter.isAnnotationPresent(EmbedParam.class)) {
+            final EmbedParam annotation = parameter.getAnnotation(EmbedParam.class);
+            result = process(parameter, UseCase.forAnnotation(annotation), annotation.value(), annotation.nullable());
+        } else if (parameter.isAnnotationPresent(MapParam.class)) {
+            final MapParam annotation = parameter.getAnnotation(MapParam.class);
+            result = process(parameter, UseCase.forAnnotation(annotation), annotation.value(), annotation.nullable());
+        } else if (parameter.isAnnotationPresent(ValueParam.class)) {
+            final ValueParam annotation = parameter.getAnnotation(ValueParam.class);
+            result = process(parameter, UseCase.forAnnotation(annotation), annotation.value(), annotation.nullable());
+        } else {
+            final MethodParam annotation = parameter.getAnnotation(MethodParam.class);
+            result = new ParameterContext(UseCase.forAnnotation(annotation),
+                    annotation.value(), annotation.nullable(), annotation.repeat());
+        }
+        return result;
+    }
+
+    @NotNull
+    private static ParameterContext process(@NotNull final Parameter parameter,
+                                            @NotNull final UseCase useCase,
+                                            @NotNull final String value,
+                                            final boolean nullable) {
+        return new ParameterContext(useCase,
+                findName(parameter, value),
+                isNullable(parameter, nullable),
+                Collection.class.isAssignableFrom(parameter.getType()));
+    }
+
+    @SuppressWarnings("deprecation")
+    public static boolean supports(@NotNull final Parameter parameter) {
+        return parameter.isAnnotationPresent(MethodParam.class)
+                || parameter.isAnnotationPresent(ValueParam.class)
+                || parameter.isAnnotationPresent(MapParam.class)
+                || parameter.isAnnotationPresent(EmbedParam.class);
+    }
+
+    private static String findName(@NotNull final Parameter parameter,
+                                   @NotNull final String annotationValue) {
+        String paramName = StringUtils.trimToNull(annotationValue);
+        if (paramName == null) {
+            paramName = processAnnotation(parameter, Qualifier.class, Qualifier::value);
+        }
+        if (paramName == null) {
+            paramName = processAnnotation(parameter, Named.class, Named::value);
+        }
+        return Objects.requireNonNullElse(paramName, parameter.getName());
+    }
+
+    private static boolean isNullable(@NotNull final Parameter parameter,
+                                      final boolean annotationValue) {
+        return parameter.isAnnotationPresent(javax.annotation.Nullable.class)
+                || parameter.isAnnotationPresent(org.springframework.lang.Nullable.class)
+                || annotationValue;
+    }
+
+    @Nullable
+    private static <A extends Annotation> String processAnnotation(@NotNull final Parameter parameter,
+                                                                   @NotNull final Class<A> annotation,
+                                                                   @NotNull final Function<A, String> nameFunction) {
+        String paramName = null;
+        if (parameter.isAnnotationPresent(annotation)) {
+            paramName = StringUtils.trimToNull(nameFunction.apply(parameter.getAnnotation(annotation)));
+        }
+        return paramName;
+    }
+
+    public enum UseCase {
+        /**
+         * Represents the use case of {@link String} valued parameter(s).
+         */
+        VALUE(RawConfigParam::asString, RawConfigParam::asStrings),
+        /**
+         * Represents the use case of {@link String} valued {@link java.util.Map} parameter(s).
+         */
+        MAP(RawConfigParam::asStringMap, RawConfigParam::asStringMaps),
+        /**
+         * Represents the use case of {@link java.util.Map} parameter(s) meant to be embedded.
+         */
+        EMBEDDED(RawConfigParam::asMap, RawConfigParam::asMaps);
+
+        private final Function<RawConfigParam, Object> singularFunction;
+        private final Function<RawConfigParam, Collection<?>> collectionFunction;
+
+        UseCase(final Function<RawConfigParam, Object> singularFunction,
+                final Function<RawConfigParam, Collection<?>> collectionFunction) {
+            this.singularFunction = singularFunction;
+            this.collectionFunction = collectionFunction;
+        }
+
+        @SuppressWarnings("deprecation")
+        static UseCase forAnnotation(final MethodParam methodParam) {
+            if (methodParam.stringMap() && methodParam.paramMap()) {
+                return EMBEDDED;
+            } else if (methodParam.stringMap()) {
+                return MAP;
+            } else {
+                Assert.isTrue(!methodParam.paramMap(), "Param map cannot be active if string map isn't.");
+                return VALUE;
+            }
+        }
+
+        @SuppressWarnings("unused")
+        static UseCase forAnnotation(final MapParam methodParam) {
+            return MAP;
+        }
+
+        @SuppressWarnings("unused")
+        static UseCase forAnnotation(final EmbedParam methodParam) {
+            return EMBEDDED;
+        }
+
+        @SuppressWarnings("unused")
+        static UseCase forAnnotation(final ValueParam methodParam) {
+            return VALUE;
+        }
+
+        public Object apply(@NotNull final RawConfigParam param, final boolean collectionNeeded) {
+            if (collectionNeeded) {
+                return collectionFunction.apply(param);
+            } else {
+                return singularFunction.apply(param);
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/RawConfigParam.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/RawConfigParam.java
@@ -1,5 +1,6 @@
 package com.github.nagyesta.yippeekijson.core.config.parser.raw;
 
+import com.github.nagyesta.yippeekijson.core.config.parser.impl.ParameterContext;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -70,13 +71,29 @@ public interface RawConfigParam {
     }
 
     /**
-     * Finds the suitable represantation based on the input parameters and the existing values.
+     * Returns the value as a single {@link String} {@link Map} (if supported).
      *
-     * @param stringMap If a plain {@link String} {@link Map} should be returned.
-     * @param paramMap  If {@link Map} values should be wrapped as {@link RawConfigParam}.
-     * @param repeat    If a {@link Collection} should be returned.
+     * @return value
+     */
+    default Map<String, String> asStringMap() {
+        throw new UnsupportedOperationException("Conversion is not supported from: " + this.getClass());
+    }
+
+    /**
+     * Returns the value as a {@link Collection} of {@link String} {@link Map} values (if supported).
+     *
+     * @return value
+     */
+    default Collection<Map<String, String>> asStringMaps() {
+        return Collections.singletonList(asStringMap());
+    }
+
+    /**
+     * Finds the suitable representation based on the input parameters and the existing values.
+     *
+     * @param context The context where we want to use the configuration values.
      * @return the converted config
      */
     @NotNull
-    Object suitableFor(boolean stringMap, boolean paramMap, boolean repeat);
+    Object suitableFor(ParameterContext context);
 }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/RawJsonAction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/RawJsonAction.java
@@ -4,12 +4,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Raw class for parsing JsonAction configuration.
@@ -25,22 +26,29 @@ public class RawJsonAction {
     @Valid
     private List<RawJsonRule> rules = Collections.emptyList();
 
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
         }
+
         if (!(o instanceof RawJsonAction)) {
             return false;
         }
 
-        final RawJsonAction that = (RawJsonAction) o;
+        RawJsonAction that = (RawJsonAction) o;
 
-        return Objects.equals(name, that.name);
+        return new EqualsBuilder()
+                .append(name, that.name)
+                .isEquals();
     }
 
+    @SuppressWarnings("checkstyle:MagicNumber")
     @Override
     public int hashCode() {
-        return Objects.hash(name);
+        return new HashCodeBuilder(17, 37)
+                .append(name)
+                .toHashCode();
     }
 }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/RawJsonRule.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/RawJsonRule.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.util.CollectionUtils;
 
 import javax.validation.Valid;
@@ -53,8 +54,8 @@ public class RawJsonRule {
      * @return The preprocessed map.
      */
     @NotNull
-    public Map<String, RawConfigParam> configParamMap(@NonNull final String param) {
-        if (CollectionUtils.isEmpty(params) || !params.containsKey(param)) {
+    public Map<String, RawConfigParam> configParamMap(@Nullable final String param) {
+        if (param == null || CollectionUtils.isEmpty(params) || !params.containsKey(param)) {
             return Collections.emptyMap();
         }
         return new RawConfigMap(getConfigPath(param), params.get(param)).asMap();
@@ -107,13 +108,6 @@ public class RawJsonRule {
             final RawJsonRule rawJsonRule = new RawJsonRule(this);
             this.reset();
             return rawJsonRule;
-        }
-
-        public String toString() {
-            return "RawJsonRule.RawJsonRuleBuilder(order=" + this.order
-                    + ", name=" + this.name
-                    + ", path=" + this.path
-                    + ", params=" + this.params + ")";
         }
     }
 }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/params/RawParamConverter.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/params/RawParamConverter.java
@@ -35,6 +35,10 @@ public class RawParamConverter implements Function<Object, RawConfigParam> {
             RawConfigParam param;
             if (rawValue instanceof String) {
                 param = asString((String) rawValue);
+            } else if (rawValue instanceof Integer
+                    || rawValue instanceof Double
+                    || rawValue instanceof Boolean) {
+                param = asString(String.valueOf(rawValue));
             } else if (rawValue instanceof Map) {
                 param = asMap((Map<String, Object>) rawValue);
             } else if (allInstanceOf((List<?>) rawValue, String.class)) {
@@ -82,7 +86,10 @@ public class RawParamConverter implements Function<Object, RawConfigParam> {
             Assert.notEmpty((Collection<?>) rawValue, "Input collection cannot be empty.");
         } else if (rawValue instanceof Map) {
             Assert.notEmpty((Map<?, ?>) rawValue, "Input map cannot be empty.");
-        } else if (!(rawValue instanceof String)) {
+        } else if (!(rawValue instanceof String
+                || rawValue instanceof Integer
+                || rawValue instanceof Double
+                || rawValue instanceof Boolean)) {
             throw new IllegalArgumentException("Parameter type is not compatible: " + rawValue.getClass());
         }
     }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/validation/JsonPathValidator.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/validation/JsonPathValidator.java
@@ -1,7 +1,7 @@
 package com.github.nagyesta.yippeekijson.core.config.validation;
 
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -22,7 +22,7 @@ public class JsonPathValidator implements ConstraintValidator<JsonPath, String> 
     }
 
     @Override
-    public boolean isValid(@Nullable final String value, @NonNull final ConstraintValidatorContext context) {
+    public boolean isValid(@Nullable final String value, @NotNull final ConstraintValidatorContext context) {
         boolean result = false;
         if (StringUtils.hasText(value)) {
             try {

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/config/validation/YippeeConfigValidator.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/config/validation/YippeeConfigValidator.java
@@ -2,6 +2,7 @@ package com.github.nagyesta.yippeekijson.core.config.validation;
 
 import com.github.nagyesta.yippeekijson.core.config.entities.RunConfig;
 import lombok.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -129,7 +130,7 @@ public class YippeeConfigValidator implements ConstraintValidator<ValidYippeeCon
      * @param obj the config that contains the input file
      * @return the input wrapped with optional
      */
-    protected Optional<File> getOptionalInput(@NonNull final RunConfig obj) {
+    protected Optional<File> getOptionalInput(@NotNull final RunConfig obj) {
         if (obj.getInput() == null) {
             return Optional.empty();
         } else {

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/control/JsonTransformer.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/control/JsonTransformer.java
@@ -6,6 +6,7 @@ import lombok.NonNull;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 
 /**
  * Applies the provided actions to the JSON streams.
@@ -15,20 +16,22 @@ public interface JsonTransformer {
     /**
      * Applies the rules from the action parameter to the JSON file on the input stream.
      *
-     * @param json   The input stream.
-     * @param action The action to be applied.
+     * @param json    The input stream.
+     * @param charset The character set used on the stream.
+     * @param action  The action to be applied.
      * @return The pretty-printed String of the transformed JSON.
      * @throws JsonTransformException When the transform operation is not possible.
      */
-    String transform(@NonNull InputStream json, @NonNull JsonAction action) throws JsonTransformException;
+    String transform(@NonNull InputStream json, @NonNull Charset charset, @NonNull JsonAction action) throws JsonTransformException;
 
     /**
      * Applies the rules from the action parameter to the JSON file.
      *
-     * @param json   The input file.
-     * @param action The action to be applied.
+     * @param json    The input file.
+     * @param charset The character set used on the stream.
+     * @param action  The action to be applied.
      * @return The pretty-printed String of the transformed JSON.
      * @throws JsonTransformException When the transform operation is not possible.
      */
-    String transform(@NonNull File json, @NonNull JsonAction action) throws JsonTransformException;
+    String transform(@NonNull File json, @NonNull Charset charset, @NonNull JsonAction action) throws JsonTransformException;
 }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/control/JsonTransformerImpl.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/control/JsonTransformerImpl.java
@@ -3,6 +3,7 @@ package com.github.nagyesta.yippeekijson.core.control;
 import com.github.nagyesta.yippeekijson.core.config.entities.JsonAction;
 import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
 import com.github.nagyesta.yippeekijson.core.exception.JsonTransformException;
+import com.github.nagyesta.yippeekijson.core.exception.StopRuleProcessingException;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
@@ -17,7 +18,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 
 @Slf4j
 @Component
@@ -31,18 +32,23 @@ public class JsonTransformerImpl implements JsonTransformer {
     }
 
     @Override
-    public String transform(@NonNull final InputStream json, @NonNull final JsonAction action) throws JsonTransformException {
+    public String transform(@NonNull final InputStream json,
+                            @NonNull final Charset charset,
+                            @NonNull final JsonAction action) throws JsonTransformException {
         try {
             if (action.getRules().isEmpty()) {
                 log.info("No rules found for action: " + action.getName() + ". Copying JSON without change.");
-                return StreamUtils.copyToString(json, StandardCharsets.UTF_8);
+                return StreamUtils.copyToString(json, charset);
             }
             final Configuration configuration = mapper.parserConfiguration();
             final DocumentContext documentContext = JsonPath.parse(json, configuration);
             log.info("Parsed JSON document.");
 
-            action.getRules().forEach(a -> a.accept(documentContext));
-
+            try {
+                action.getRules().forEach(rule -> rule.accept(documentContext));
+            } catch (final StopRuleProcessingException e) {
+                log.error("Rule processing is stopped: " + e.getMessage());
+            }
             return JsonFormatter.prettyPrint(documentContext.jsonString());
         } catch (final Exception e) {
             log.error(e.getMessage(), e);
@@ -51,10 +57,12 @@ public class JsonTransformerImpl implements JsonTransformer {
     }
 
     @Override
-    public String transform(@NonNull final File json, @NonNull final JsonAction action) throws JsonTransformException {
+    public String transform(@NonNull final File json,
+                            @NonNull final Charset charset,
+                            @NonNull final JsonAction action) throws JsonTransformException {
         log.info("Processing file: " + json.getAbsolutePath() + " using action: " + action.getName());
         try (FileInputStream inputStream = new FileInputStream(json)) {
-            return transform(inputStream, action);
+            return transform(inputStream, charset, action);
         } catch (final IOException e) {
             log.error(e.getMessage(), e);
             throw new JsonTransformException("IOException happened while processing JSON.", e);

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/exception/AbortTransformationException.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/exception/AbortTransformationException.java
@@ -1,0 +1,16 @@
+package com.github.nagyesta.yippeekijson.core.exception;
+
+/**
+ * Used when the caller must stop processing the current file and throw away partial results.
+ */
+public class AbortTransformationException extends RuntimeException {
+
+    /**
+     * Creates a new instance and sets the message.
+     *
+     * @param message the message
+     */
+    public AbortTransformationException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/exception/StopRuleProcessingException.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/exception/StopRuleProcessingException.java
@@ -1,0 +1,16 @@
+package com.github.nagyesta.yippeekijson.core.exception;
+
+/**
+ * Exception type used to signal the need for termination in rule processing.
+ */
+public class StopRuleProcessingException extends RuntimeException {
+
+    /**
+     * Creates a new instance and sets the message.
+     *
+     * @param message the message
+     */
+    public StopRuleProcessingException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/ChangeCaseFunction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/ChangeCaseFunction.java
@@ -1,7 +1,7 @@
 package com.github.nagyesta.yippeekijson.core.function;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedFunction;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
@@ -23,7 +23,7 @@ public final class ChangeCaseFunction implements Function<String, String> {
     private final Case to;
 
     @NamedFunction(NAME)
-    public ChangeCaseFunction(@MethodParam(PARAM_TO) @NonNull final String to) {
+    public ChangeCaseFunction(@ValueParam(PARAM_TO) @NonNull final String to) {
         this.to = Case.parse(to);
     }
 

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/CloneKeyFunction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/CloneKeyFunction.java
@@ -1,7 +1,7 @@
 package com.github.nagyesta.yippeekijson.core.function;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedFunction;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,8 +24,8 @@ public final class CloneKeyFunction implements Function<Map<String, Object>, Map
     private final String to;
 
     @NamedFunction(NAME)
-    public CloneKeyFunction(@MethodParam(PARAM_FROM) @NonNull final String from,
-                            @MethodParam(PARAM_TO) @NonNull final String to) {
+    public CloneKeyFunction(@ValueParam(PARAM_FROM) @NonNull final String from,
+                            @ValueParam(PARAM_TO) @NonNull final String to) {
         this.from = from;
         this.to = to;
     }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/DecimalAddFunction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/DecimalAddFunction.java
@@ -1,7 +1,8 @@
 package com.github.nagyesta.yippeekijson.core.function;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedFunction;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
+import com.github.nagyesta.yippeekijson.core.function.helper.DecimalFunctionSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,15 +13,15 @@ import java.util.function.BiFunction;
  * {@link java.util.function.Function} for addition of a decimal value.
  */
 @Slf4j
-public final class DecimalAddFunction extends DecimalFunction {
+public final class DecimalAddFunction extends DecimalFunctionSupport {
 
     static final String NAME = "add";
     static final String PARAM_OPERAND = "operand";
     static final String PARAM_SCALE = "scale";
 
     @NamedFunction(NAME)
-    public DecimalAddFunction(@NotNull @MethodParam(PARAM_OPERAND) final String operand,
-                              @NotNull @MethodParam(PARAM_SCALE) final String scale) {
+    public DecimalAddFunction(@NotNull @ValueParam(PARAM_OPERAND) final String operand,
+                              @NotNull @ValueParam(PARAM_SCALE) final String scale) {
         super(operand, scale);
     }
 

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/DecimalDivideFunction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/DecimalDivideFunction.java
@@ -1,7 +1,8 @@
 package com.github.nagyesta.yippeekijson.core.function;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedFunction;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
+import com.github.nagyesta.yippeekijson.core.function.helper.DecimalFunctionSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
@@ -13,7 +14,7 @@ import java.util.function.BiFunction;
  * {@link java.util.function.Function} for division of a decimal value.
  */
 @Slf4j
-public final class DecimalDivideFunction extends DecimalFunction {
+public final class DecimalDivideFunction extends DecimalFunctionSupport {
 
     static final String NAME = "divide";
     static final String PARAM_OPERAND = "operand";
@@ -22,8 +23,8 @@ public final class DecimalDivideFunction extends DecimalFunction {
     private final int scale;
 
     @NamedFunction(NAME)
-    public DecimalDivideFunction(@NotNull @MethodParam(PARAM_OPERAND) final String operand,
-                                 @NotNull @MethodParam(PARAM_SCALE) final String scale) {
+    public DecimalDivideFunction(@NotNull @ValueParam(PARAM_OPERAND) final String operand,
+                                 @NotNull @ValueParam(PARAM_SCALE) final String scale) {
         super(operand, scale);
         this.scale = Integer.parseInt(scale);
     }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/DecimalMultiplyFunction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/DecimalMultiplyFunction.java
@@ -1,7 +1,8 @@
 package com.github.nagyesta.yippeekijson.core.function;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedFunction;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
+import com.github.nagyesta.yippeekijson.core.function.helper.DecimalFunctionSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,15 +13,15 @@ import java.util.function.BiFunction;
  * {@link java.util.function.Function} for multiplying a decimal value.
  */
 @Slf4j
-public final class DecimalMultiplyFunction extends DecimalFunction {
+public final class DecimalMultiplyFunction extends DecimalFunctionSupport {
 
     static final String NAME = "multiply";
     static final String PARAM_OPERAND = "operand";
     static final String PARAM_SCALE = "scale";
 
     @NamedFunction(NAME)
-    public DecimalMultiplyFunction(@NotNull @MethodParam(PARAM_OPERAND) final String operand,
-                                   @NotNull @MethodParam(PARAM_SCALE) final String scale) {
+    public DecimalMultiplyFunction(@NotNull @ValueParam(PARAM_OPERAND) final String operand,
+                                   @NotNull @ValueParam(PARAM_SCALE) final String scale) {
         super(operand, scale);
     }
 

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/DecimalSubtractFunction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/DecimalSubtractFunction.java
@@ -1,7 +1,8 @@
 package com.github.nagyesta.yippeekijson.core.function;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedFunction;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
+import com.github.nagyesta.yippeekijson.core.function.helper.DecimalFunctionSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,15 +13,15 @@ import java.util.function.BiFunction;
  * {@link java.util.function.Function} for subtraction of a decimal value.
  */
 @Slf4j
-public final class DecimalSubtractFunction extends DecimalFunction {
+public final class DecimalSubtractFunction extends DecimalFunctionSupport {
 
     static final String NAME = "subtract";
     static final String PARAM_OPERAND = "operand";
     static final String PARAM_SCALE = "scale";
 
     @NamedFunction(NAME)
-    public DecimalSubtractFunction(@NotNull @MethodParam(PARAM_OPERAND) final String operand,
-                                   @NotNull @MethodParam(PARAM_SCALE) final String scale) {
+    public DecimalSubtractFunction(@NotNull @ValueParam(PARAM_OPERAND) final String operand,
+                                   @NotNull @ValueParam(PARAM_SCALE) final String scale) {
         super(operand, scale);
     }
 

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/EpochMilliDateAddFunction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/EpochMilliDateAddFunction.java
@@ -1,7 +1,7 @@
 package com.github.nagyesta.yippeekijson.core.function;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedFunction;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
 import com.github.nagyesta.yippeekijson.core.function.helper.ChronoUnitSupport;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -26,8 +26,8 @@ public final class EpochMilliDateAddFunction extends ChronoUnitSupport implement
     private final ChronoUnit unit;
 
     @NamedFunction(NAME)
-    public EpochMilliDateAddFunction(@MethodParam(PARAM_AMOUNT) @NonNull final String amount,
-                                     @MethodParam(PARAM_UNIT) @NonNull final String unit) {
+    public EpochMilliDateAddFunction(@ValueParam(PARAM_AMOUNT) @NonNull final String amount,
+                                     @ValueParam(PARAM_UNIT) @NonNull final String unit) {
         this.amount = Integer.parseInt(amount);
         this.unit = toChronoUnit(unit);
     }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/HttpResourceContentFunction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/HttpResourceContentFunction.java
@@ -1,0 +1,51 @@
+package com.github.nagyesta.yippeekijson.core.function;
+
+import com.github.nagyesta.yippeekijson.core.annotation.EmbedParam;
+import com.github.nagyesta.yippeekijson.core.annotation.MapParam;
+import com.github.nagyesta.yippeekijson.core.annotation.NamedFunction;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
+import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
+import com.github.nagyesta.yippeekijson.core.function.helper.HttpResourceContentSupport;
+import com.github.nagyesta.yippeekijson.core.http.HttpClient;
+import com.github.nagyesta.yippeekijson.core.http.HttpRequestContext;
+import lombok.NonNull;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * {@link Function} allowing us to fetch HTTP resources with their URI provided by the JSON path.
+ */
+public final class HttpResourceContentFunction extends HttpResourceContentSupport<String> implements Function<String, String> {
+
+    static final String NAME = "httpResourceByUri";
+    private final Function<String, String> uriFunction;
+
+    @NamedFunction(NAME)
+    public HttpResourceContentFunction(@EmbedParam @Nullable final Map<String, RawConfigParam> uriFunction,
+                                       @ValueParam @Nullable final String uri,
+                                       @ValueParam @Nullable final String httpMethod,
+                                       @MapParam @Nullable final Map<String, String> httpHeaders,
+                                       @ValueParam @Nullable final String charset,
+                                       @NonNull final FunctionRegistry functionRegistry,
+                                       @NotNull final HttpClient httpClient) {
+        super(httpClient, uri, httpMethod, httpHeaders, charset);
+        this.uriFunction = Optional.ofNullable(uriFunction)
+                .map(functionRegistry::<String, String>lookupFunction)
+                .orElseGet(Function::identity);
+    }
+
+    @Override
+    @NotNull
+    protected HttpRequestContext buildOverrideContext(final String uriOverride) {
+        return HttpRequestContext.builder()
+                .uri(uriFunction.apply(uriOverride))
+                .httpMethod((String) null)
+                .charset(null)
+                .build();
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/HttpResourceContentMapFunction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/HttpResourceContentMapFunction.java
@@ -1,0 +1,64 @@
+package com.github.nagyesta.yippeekijson.core.function;
+
+import com.github.nagyesta.yippeekijson.core.annotation.EmbedParam;
+import com.github.nagyesta.yippeekijson.core.annotation.MapParam;
+import com.github.nagyesta.yippeekijson.core.annotation.NamedFunction;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
+import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
+import com.github.nagyesta.yippeekijson.core.function.helper.HttpResourceContentSupport;
+import com.github.nagyesta.yippeekijson.core.http.HttpClient;
+import com.github.nagyesta.yippeekijson.core.http.HttpRequestContext;
+import lombok.NonNull;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * {@link Function} allowing us to fetch HTTP resources with their URI provided by the JSON path.
+ */
+public final class HttpResourceContentMapFunction extends HttpResourceContentSupport<Map<String, Object>>
+        implements Function<Map<String, Object>, String> {
+
+    static final String NAME = "httpResource";
+    private final Function<Map<String, Object>, String> uriFunction;
+    private final Function<Map<String, Object>, String> methodFunction;
+    private final Function<Map<String, Object>, Map<String, String>> headerFunction;
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    @NamedFunction(NAME)
+    public HttpResourceContentMapFunction(@EmbedParam @Nullable final Map<String, RawConfigParam> uriFunction,
+                                          @EmbedParam @Nullable final Map<String, RawConfigParam> methodFunction,
+                                          @EmbedParam @Nullable final Map<String, RawConfigParam> headerFunction,
+                                          @ValueParam @Nullable final String uri,
+                                          @ValueParam @Nullable final String httpMethod,
+                                          @MapParam @Nullable final Map<String, String> httpHeaders,
+                                          @ValueParam @Nullable final String charset,
+                                          @NonNull final FunctionRegistry functionRegistry,
+                                          @NotNull final HttpClient httpClient) {
+        super(httpClient, uri, httpMethod, httpHeaders, charset);
+        this.uriFunction = Optional.ofNullable(uriFunction)
+                .map(functionRegistry::<Map<String, Object>, String>lookupFunction)
+                .orElseGet(() -> ignore -> null);
+        this.methodFunction = Optional.ofNullable(methodFunction)
+                .map(functionRegistry::<Map<String, Object>, String>lookupFunction)
+                .orElseGet(() -> ignore -> null);
+        this.headerFunction = Optional.ofNullable(headerFunction)
+                .map(functionRegistry::<Map<String, Object>, Map<String, String>>lookupFunction)
+                .orElseGet(() -> map -> Collections.emptyMap());
+    }
+
+    @Override
+    @NotNull
+    protected HttpRequestContext buildOverrideContext(final Map<String, Object> mapOverride) {
+        return HttpRequestContext.builder()
+                .uri(uriFunction.apply(mapOverride))
+                .httpMethod(methodFunction.apply(mapOverride))
+                .addHeaders(headerFunction.apply(mapOverride))
+                .build();
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/JsonParseFunction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/JsonParseFunction.java
@@ -1,0 +1,43 @@
+package com.github.nagyesta.yippeekijson.core.function;
+
+import com.github.nagyesta.yippeekijson.core.annotation.NamedFunction;
+import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
+import com.github.nagyesta.yippeekijson.core.exception.AbortTransformationException;
+import com.jayway.jsonpath.JsonPath;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.StringJoiner;
+import java.util.function.Function;
+
+/**
+ * {@link Function} for parsing a JSON {@link String} into a {@link Object}.
+ */
+@Slf4j
+public final class JsonParseFunction implements Function<String, Object> {
+
+    static final String NAME = "jsonParse";
+
+    private final JsonMapper jsonMapper;
+
+    @NamedFunction(NAME)
+    public JsonParseFunction(@NonNull final JsonMapper jsonMapper) {
+        this.jsonMapper = jsonMapper;
+    }
+
+    @Override
+    public Object apply(final String s) {
+        try {
+            return JsonPath.parse(s, jsonMapper.parserConfiguration()).json();
+        } catch (final Exception e) {
+            log.error("Failed to parse input: " + e.getMessage(), e);
+            throw new AbortTransformationException("Failed to parse input: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", JsonParseFunction.class.getSimpleName() + "[", "]")
+                .toString();
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/LiteralReplaceFunction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/LiteralReplaceFunction.java
@@ -1,7 +1,7 @@
 package com.github.nagyesta.yippeekijson.core.function;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedFunction;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
@@ -23,8 +23,8 @@ public final class LiteralReplaceFunction implements Function<String, String> {
     private final String replace;
 
     @NamedFunction(NAME)
-    public LiteralReplaceFunction(@MethodParam(PARAM_FIND) @NonNull final String find,
-                                  @MethodParam(PARAM_REPLACE) @NonNull final String replace) {
+    public LiteralReplaceFunction(@ValueParam(PARAM_FIND) @NonNull final String find,
+                                  @ValueParam(PARAM_REPLACE) @NonNull final String replace) {
         this.find = find;
         this.replace = replace;
     }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/RegexReplaceFunction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/RegexReplaceFunction.java
@@ -1,7 +1,7 @@
 package com.github.nagyesta.yippeekijson.core.function;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedFunction;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,8 +26,8 @@ public final class RegexReplaceFunction implements Function<String, String> {
     private final String replacement;
 
     @NamedFunction(NAME)
-    public RegexReplaceFunction(@MethodParam(PARAM_PATTERN) @NonNull final String pattern,
-                                @MethodParam(PARAM_REPLACEMENT) @NonNull final String replacement) {
+    public RegexReplaceFunction(@ValueParam(PARAM_PATTERN) @NonNull final String pattern,
+                                @ValueParam(PARAM_REPLACEMENT) @NonNull final String replacement) {
         this.pattern = Pattern.compile(pattern);
         this.replacement = replacement;
     }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/StringDateAddFunction.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/StringDateAddFunction.java
@@ -1,7 +1,7 @@
 package com.github.nagyesta.yippeekijson.core.function;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedFunction;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
 import com.github.nagyesta.yippeekijson.core.function.helper.ChronoUnitSupport;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -34,9 +34,9 @@ public final class StringDateAddFunction extends ChronoUnitSupport implements Fu
     private final ChronoUnit unit;
 
     @NamedFunction(NAME)
-    public StringDateAddFunction(@MethodParam(PARAM_FORMATTER) @NonNull final String formatter,
-                                 @MethodParam(PARAM_AMOUNT) @NonNull final String amount,
-                                 @MethodParam(PARAM_UNIT) @NonNull final String unit) {
+    public StringDateAddFunction(@ValueParam(PARAM_FORMATTER) @NonNull final String formatter,
+                                 @ValueParam(PARAM_AMOUNT) @NonNull final String amount,
+                                 @ValueParam(PARAM_UNIT) @NonNull final String unit) {
         this.formatterPattern = formatter;
         this.dateTimeFormatter = DateTimeFormatter.ofPattern(formatter);
         this.amount = Integer.parseInt(amount);

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/helper/DecimalFunctionSupport.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/helper/DecimalFunctionSupport.java
@@ -1,4 +1,4 @@
-package com.github.nagyesta.yippeekijson.core.function;
+package com.github.nagyesta.yippeekijson.core.function.helper;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -14,12 +14,12 @@ import java.util.function.Function;
  * {@link Function} for replacing {@link String} values using a RegExp .
  */
 @Slf4j
-public abstract class DecimalFunction implements Function<BigDecimal, BigDecimal> {
+public abstract class DecimalFunctionSupport implements Function<BigDecimal, BigDecimal> {
 
     private final BigDecimal operand;
     private final int scale;
 
-    public DecimalFunction(@NonNull final String operand, @NonNull final String scale) {
+    public DecimalFunctionSupport(@NonNull final String operand, @NonNull final String scale) {
         this.operand = new BigDecimal(operand);
         this.scale = Integer.parseInt(scale);
     }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/function/helper/HttpResourceContentSupport.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/function/helper/HttpResourceContentSupport.java
@@ -1,0 +1,54 @@
+package com.github.nagyesta.yippeekijson.core.function.helper;
+
+import com.github.nagyesta.yippeekijson.core.http.HttpClient;
+import com.github.nagyesta.yippeekijson.core.http.HttpRequestContext;
+import lombok.NonNull;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.function.Function;
+
+/**
+ * {@link Function} allowing us to fetch resources over HTTP.
+ *
+ * @param <T> The type of the input data we have
+ */
+public abstract class HttpResourceContentSupport<T> implements Function<T, String> {
+
+    private final HttpRequestContext httpRequestContext;
+    private final HttpClient httpClient;
+
+    public HttpResourceContentSupport(@NonNull final HttpClient httpClient,
+                                      @Nullable final String uri,
+                                      @Nullable final String method,
+                                      @Nullable final Map<String, String> headers,
+                                      @Nullable final String charset) {
+        this.httpRequestContext = new HttpRequestContext(uri, method, headers, charset);
+        this.httpClient = httpClient;
+    }
+
+
+    @Override
+    public String apply(final T override) {
+        final HttpRequestContext overrides = buildOverrideContext(override);
+        return httpClient.fetch(httpRequestContext, overrides);
+    }
+
+    /**
+     * Generates the override context for the HTTP call to let us merge and fetch based on it.
+     *
+     * @param override The override values we should use for the context creation.
+     * @return An {@link HttpRequestContext} containing all of the override values.
+     */
+    @NotNull
+    protected abstract HttpRequestContext buildOverrideContext(T override);
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", this.getClass().getSimpleName() + "[", "]")
+                .add("httpRequestContext=" + httpRequestContext)
+                .toString();
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/http/HttpClient.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/http/HttpClient.java
@@ -1,0 +1,32 @@
+package com.github.nagyesta.yippeekijson.core.http;
+
+import com.github.nagyesta.yippeekijson.core.exception.AbortTransformationException;
+import lombok.NonNull;
+
+/**
+ * Defines how the HTTP client abstraction behaves.
+ */
+public interface HttpClient {
+
+    /**
+     * Fetches a resource over HTTP based on the {@link HttpRequestContext}.
+     *
+     * @param requestContext The context defining how the resource should be accessed
+     * @return The {@link String} contents of the resource
+     * @throws AbortTransformationException If the fetching fails for any reason.
+     */
+    String fetch(@NonNull HttpRequestContext requestContext) throws AbortTransformationException;
+
+    /**
+     * Fetches a resource over HTTP based on the merger {@link HttpRequestContext}.
+     * During the merge, if a value is present in the overrides, it will be used from the overrides.
+     * If an HTTP header is present on both sides, the value in the baseContext will be ignored.
+     *
+     * @param baseContext The base context providing the defaults
+     * @param overrides   The override context providing values to be applied on top of the defaults
+     * @return The {@link String} contents of the resource
+     * @throws AbortTransformationException If the fetching fails for any reason.
+     */
+    String fetch(@NonNull HttpRequestContext baseContext,
+                 @NonNull HttpRequestContext overrides) throws AbortTransformationException;
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/http/HttpRequestContext.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/http/HttpRequestContext.java
@@ -1,0 +1,185 @@
+package com.github.nagyesta.yippeekijson.core.http;
+
+import com.google.common.net.HttpHeaders;
+import lombok.Getter;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+/**
+ * Entity class containing vital input parameters for an {@link HttpRequest}.
+ */
+@Getter
+public final class HttpRequestContext {
+
+    private final String uri;
+    private final HttpMethod httpMethod;
+    private final Map<String, List<String>> headers;
+    private final Charset charset;
+
+    public HttpRequestContext(@Nullable final String uri,
+                              @Nullable final String method,
+                              @Nullable final Map<String, String> headers,
+                              @Nullable final String charset) {
+        this.uri = uri;
+        this.httpMethod = Optional.ofNullable(method).map(HttpMethod::valueOf).orElse(HttpRequestContext.HttpMethod.GET);
+        this.headers = new TreeMap<>();
+        Optional.ofNullable(headers).orElse(Collections.emptyMap())
+                .forEach((k, v) -> this.headers.put(k, List.of(v)));
+        this.charset = Optional.ofNullable(charset).map(Charset::forName).orElse(StandardCharsets.UTF_8);
+        this.headers.putIfAbsent(HttpHeaders.ACCEPT_CHARSET, List.of(this.charset.name()));
+    }
+
+    private HttpRequestContext(final HttpRequestContextBuilder builder) {
+        this.uri = builder.uri;
+        this.httpMethod = builder.httpMethod;
+        this.headers = new TreeMap<>();
+        builder.headers.forEach((k, v) -> headers.put(k, List.copyOf(v)));
+        this.charset = builder.charset;
+        if (charset != null) {
+            this.headers.putIfAbsent(HttpHeaders.ACCEPT_CHARSET, List.of(this.charset.name()));
+        }
+    }
+
+    public static HttpRequestContextBuilder builder() {
+        return new HttpRequestContextBuilder();
+    }
+
+    public HttpRequestContext withOverrides(final HttpRequestContext overrides) {
+        final HttpRequestContextBuilder contextBuilder = builder()
+                .uri(Objects.requireNonNullElse(overrides.getUri(), this.uri))
+                .httpMethod(Objects.requireNonNullElse(overrides.getHttpMethod(), this.httpMethod))
+                .charset(Objects.requireNonNullElse(overrides.getCharset(), this.charset));
+        this.headers.forEach((k, v) -> overrides.getHeaders().getOrDefault(k, v)
+                .forEach(listItem -> contextBuilder.addHeader(k, listItem)));
+        overrides.getHeaders().entrySet().stream()
+                .filter(e -> !this.headers.containsKey(e.getKey()))
+                .forEach(e -> e.getValue()
+                        .forEach(listItem -> contextBuilder.addHeader(e.getKey(), listItem)));
+        return contextBuilder.build();
+    }
+
+    public HttpRequest.Builder toHttpRequestBuilder() {
+        final HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .method(this.httpMethod.name(), HttpRequest.BodyPublishers.noBody())
+                .uri(URI.create(this.uri));
+        headers.forEach((name, list) -> list.forEach(value -> builder.header(name, value)));
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", HttpRequestContext.class.getSimpleName() + "[", "]")
+                .add("uri='" + uri + "'")
+                .add("httpMethod='" + httpMethod + "'")
+                .add("charset='" + charset.name() + "'")
+                .add("headers=" + headers)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof HttpRequestContext)) {
+            return false;
+        }
+
+        HttpRequestContext that = (HttpRequestContext) o;
+
+        return new EqualsBuilder()
+                .append(uri, that.uri)
+                .append(httpMethod, that.httpMethod)
+                .append(headers, that.headers)
+                .append(charset, that.charset)
+                .isEquals();
+    }
+
+    @SuppressWarnings("checkstyle:MagicNumber")
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(uri)
+                .append(httpMethod)
+                .append(headers)
+                .append(charset)
+                .toHashCode();
+    }
+
+    public enum HttpMethod {
+        /**
+         * HTTP GET method.
+         */
+        GET,
+        /**
+         * HTTP POST method.
+         */
+        POST
+    }
+
+    @SuppressWarnings({"UnusedReturnValue", "checkstyle:HiddenField", "checkstyle:DesignForExtension"})
+    public static class HttpRequestContextBuilder {
+        private String uri;
+        private HttpMethod httpMethod;
+        private Map<String, List<String>> headers;
+        private Charset charset;
+
+        HttpRequestContextBuilder() {
+            reset();
+        }
+
+        private void reset() {
+            this.uri = null;
+            this.httpMethod = HttpMethod.GET;
+            this.headers = new TreeMap<>();
+            this.charset = StandardCharsets.UTF_8;
+        }
+
+        public HttpRequestContextBuilder uri(@Nullable final String uri) {
+            this.uri = uri;
+            return this;
+        }
+
+        public HttpRequestContextBuilder httpMethod(@NotNull final HttpMethod httpMethod) {
+            this.httpMethod = httpMethod;
+            return this;
+        }
+
+        public HttpRequestContextBuilder httpMethod(@Nullable final String httpMethod) {
+            this.httpMethod = Optional.ofNullable(httpMethod).map(HttpMethod::valueOf).orElse(null);
+            return this;
+        }
+
+        public HttpRequestContextBuilder addHeader(@NotNull final String name,
+                                                   @NotNull final String value) {
+            final List<String> stringList = headers.getOrDefault(name, new ArrayList<>());
+            stringList.add(value);
+            this.headers.put(name, stringList);
+            return this;
+        }
+
+        public HttpRequestContextBuilder addHeaders(@NotNull final Map<String, String> headers) {
+            headers.forEach(this::addHeader);
+            return this;
+        }
+
+        public HttpRequestContextBuilder charset(@Nullable final Charset charset) {
+            this.charset = charset;
+            return this;
+        }
+
+        public HttpRequestContext build() {
+            final HttpRequestContext requestContext = new HttpRequestContext(this);
+            this.reset();
+            return requestContext;
+        }
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/http/impl/DefaultHttpClient.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/http/impl/DefaultHttpClient.java
@@ -1,0 +1,66 @@
+package com.github.nagyesta.yippeekijson.core.http.impl;
+
+import com.github.nagyesta.yippeekijson.core.annotation.Injectable;
+import com.github.nagyesta.yippeekijson.core.config.entities.HttpConfig;
+import com.github.nagyesta.yippeekijson.core.exception.AbortTransformationException;
+import com.github.nagyesta.yippeekijson.core.http.HttpClient;
+import com.github.nagyesta.yippeekijson.core.http.HttpRequestContext;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import static com.google.common.net.HttpHeaders.ACCEPT;
+import static com.google.common.net.HttpHeaders.USER_AGENT;
+import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
+
+@Slf4j
+@Injectable(forType = HttpClient.class)
+public class DefaultHttpClient implements HttpClient {
+
+    private final HttpConfig httpConfig;
+
+    public DefaultHttpClient(final HttpConfig httpConfig) {
+        this.httpConfig = httpConfig;
+    }
+
+    @Override
+    public String fetch(@NonNull final HttpRequestContext requestContext) {
+        try {
+            log.info("Sending request: " + requestContext);
+            HttpRequest httpRequest = buildHttpRequest(requestContext);
+            final HttpResponse<String> httpResponse = java.net.http.HttpClient.newHttpClient()
+                    .send(httpRequest, HttpResponse.BodyHandlers.ofString(requestContext.getCharset()));
+            final int statusCode = httpResponse.statusCode();
+            if (httpConfig.getMinSuccessStatus() <= statusCode && statusCode <= httpConfig.getMaxSuccessStatus()) {
+                return httpResponse.body();
+            } else {
+                throw new IllegalStateException("Http request failed with status: " + statusCode);
+            }
+        } catch (final Exception e) {
+            log.error("Failed to fetch resource from: " + requestContext.getUri() + " due to: " + e.getMessage(), e);
+            throw new AbortTransformationException("Failed to fetch resource from: " + requestContext.getUri());
+        }
+    }
+
+    private HttpRequest buildHttpRequest(@NotNull final HttpRequestContext requestContext) {
+        final HttpRequest.Builder builder = requestContext.toHttpRequestBuilder();
+        if (httpConfig.getTimeoutSeconds() > 0) {
+            builder.timeout(Duration.ofSeconds(httpConfig.getTimeoutSeconds()));
+        }
+        if (httpConfig.isAddDefaultHeaders()) {
+            builder.header(USER_AGENT, httpConfig.getUserAgent());
+            builder.header(ACCEPT, APPLICATION_JSON_VALUE);
+        }
+        return builder.build();
+    }
+
+    @Override
+    public String fetch(@NonNull final HttpRequestContext baseContext,
+                        @NonNull final HttpRequestContext overrides) {
+        return this.fetch(baseContext.withOverrides(overrides));
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/AllMatchPredicate.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/AllMatchPredicate.java
@@ -1,9 +1,10 @@
 package com.github.nagyesta.yippeekijson.core.predicate;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
+import com.github.nagyesta.yippeekijson.core.annotation.EmbedParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedPredicate;
 import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
 import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
+import com.github.nagyesta.yippeekijson.core.predicate.helper.CombiningPredicateSupport;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,14 +14,13 @@ import java.util.Map;
 /**
  * {@link java.util.function.Predicate} evaluating a collection of embedded predicates and ensures that all of them are matching.
  */
-public final class AllMatchPredicate extends CombiningPredicate {
+public final class AllMatchPredicate extends CombiningPredicateSupport {
 
     static final String NAME = "allMatch";
     static final String PARAM_FROM = "from";
 
     @NamedPredicate(NAME)
-    public AllMatchPredicate(@MethodParam(value = PARAM_FROM, stringMap = true, repeat = true, paramMap = true)
-                             @NotNull final Collection<Map<String, RawConfigParam>> fromPredicates,
+    public AllMatchPredicate(@EmbedParam(PARAM_FROM) @NotNull final Collection<Map<String, RawConfigParam>> fromPredicates,
                              @NotNull final FunctionRegistry functionRegistry) {
         super(fromPredicates, functionRegistry);
     }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/AnyMatchPredicate.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/AnyMatchPredicate.java
@@ -1,9 +1,10 @@
 package com.github.nagyesta.yippeekijson.core.predicate;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
+import com.github.nagyesta.yippeekijson.core.annotation.EmbedParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedPredicate;
 import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
 import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
+import com.github.nagyesta.yippeekijson.core.predicate.helper.CombiningPredicateSupport;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,13 +14,13 @@ import java.util.Map;
 /**
  * {@link java.util.function.Predicate} evaluating a collection of embedded predicates and ensures that at least on of them is matching.
  */
-public final class AnyMatchPredicate extends CombiningPredicate {
+public final class AnyMatchPredicate extends CombiningPredicateSupport {
 
     static final String NAME = "anyMatch";
     static final String PARAM_FROM = "from";
 
     @NamedPredicate(NAME)
-    public AnyMatchPredicate(@MethodParam(value = PARAM_FROM, stringMap = true, repeat = true, paramMap = true)
+    public AnyMatchPredicate(@EmbedParam(PARAM_FROM)
                              @NotNull final Collection<Map<String, RawConfigParam>> fromPredicates,
                              @NotNull final FunctionRegistry functionRegistry) {
         super(fromPredicates, functionRegistry);

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/ContainsKeyPredicate.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/ContainsKeyPredicate.java
@@ -1,7 +1,7 @@
 package com.github.nagyesta.yippeekijson.core.predicate;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedPredicate;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
 import com.github.nagyesta.yippeekijson.core.predicate.helper.MapSupport;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
@@ -17,12 +17,11 @@ import java.util.function.Predicate;
 public final class ContainsKeyPredicate extends MapSupport implements Predicate<Object> {
 
     static final String NAME = "containsKey";
-    static final String PARAM_KEY = "key";
 
     private final String key;
 
     @NamedPredicate(NAME)
-    public ContainsKeyPredicate(@MethodParam(PARAM_KEY) @NonNull final String key) {
+    public ContainsKeyPredicate(@ValueParam @NonNull final String key) {
         this.key = key;
     }
 

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/EvalOnPredicate.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/EvalOnPredicate.java
@@ -1,7 +1,8 @@
 package com.github.nagyesta.yippeekijson.core.predicate;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
+import com.github.nagyesta.yippeekijson.core.annotation.EmbedParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedPredicate;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
 import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
 import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
 import com.github.nagyesta.yippeekijson.core.predicate.helper.MapSupport;
@@ -21,17 +22,14 @@ import java.util.regex.Pattern;
 public final class EvalOnPredicate extends MapSupport implements Predicate<Object> {
 
     static final String NAME = "evalOn";
-    static final String PARAM_CHILD_PATH = "childPath";
-    static final String PARAM_PREDICATE = "predicate";
     static final String DELIMITER = ".";
 
     private final String childPath;
     private final Predicate<Object> wrappedPredicate;
 
     @NamedPredicate(NAME)
-    public EvalOnPredicate(@MethodParam(PARAM_CHILD_PATH) @NonNull final String childPath,
-                           @MethodParam(value = PARAM_PREDICATE, stringMap = true, paramMap = true)
-                           @NonNull final Map<String, RawConfigParam> predicate,
+    public EvalOnPredicate(@ValueParam @NonNull final String childPath,
+                           @EmbedParam @NonNull final Map<String, RawConfigParam> predicate,
                            @NonNull final FunctionRegistry functionRegistry) {
         this.childPath = childPath;
         this.wrappedPredicate = functionRegistry.lookupPredicate(predicate);

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/NoneMatchPredicate.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/NoneMatchPredicate.java
@@ -1,9 +1,10 @@
 package com.github.nagyesta.yippeekijson.core.predicate;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
+import com.github.nagyesta.yippeekijson.core.annotation.EmbedParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedPredicate;
 import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
 import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
+import com.github.nagyesta.yippeekijson.core.predicate.helper.CombiningPredicateSupport;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,13 +14,13 @@ import java.util.Map;
 /**
  * {@link java.util.function.Predicate} evaluating a collection of embedded predicates and ensures that none of them are matching.
  */
-public final class NoneMatchPredicate extends CombiningPredicate {
+public final class NoneMatchPredicate extends CombiningPredicateSupport {
 
     static final String NAME = "noneMatch";
     static final String PARAM_FROM = "from";
 
     @NamedPredicate(NAME)
-    public NoneMatchPredicate(@MethodParam(value = PARAM_FROM, stringMap = true, repeat = true, paramMap = true)
+    public NoneMatchPredicate(@EmbedParam(PARAM_FROM)
                               @NotNull final Collection<Map<String, RawConfigParam>> fromPredicates,
                               @NotNull final FunctionRegistry functionRegistry) {
         super(fromPredicates, functionRegistry);

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/RegexPredicate.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/RegexPredicate.java
@@ -1,7 +1,7 @@
 package com.github.nagyesta.yippeekijson.core.predicate;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedPredicate;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -15,12 +15,11 @@ import java.util.regex.Pattern;
 public final class RegexPredicate implements Predicate<Object> {
 
     static final String NAME = "regex";
-    static final String PARAM_PATTERN = "pattern";
 
     private final Pattern pattern;
 
     @NamedPredicate(NAME)
-    public RegexPredicate(@MethodParam(PARAM_PATTERN) @NonNull final String pattern) {
+    public RegexPredicate(@ValueParam @NonNull final String pattern) {
         this.pattern = Pattern.compile(pattern);
     }
 

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/SpringExpressionLanguagePredicate.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/SpringExpressionLanguagePredicate.java
@@ -1,7 +1,7 @@
 package com.github.nagyesta.yippeekijson.core.predicate;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedPredicate;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
 import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.expression.spel.standard.SpelExpression;
@@ -17,12 +17,11 @@ import java.util.function.Predicate;
 public final class SpringExpressionLanguagePredicate implements Predicate<Object> {
 
     static final String NAME = "SpEL";
-    static final String PARAM_EXPRESSION = "expression";
 
     private final SpelExpression expression;
 
     @NamedPredicate(NAME)
-    public SpringExpressionLanguagePredicate(@MethodParam(PARAM_EXPRESSION) @NonNull final String expression) {
+    public SpringExpressionLanguagePredicate(@ValueParam @NonNull final String expression) {
         try {
             this.expression = new SpelExpressionParser().parseRaw(expression);
         } catch (final Exception e) {

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/helper/CombiningPredicateSupport.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/predicate/helper/CombiningPredicateSupport.java
@@ -1,4 +1,4 @@
-package com.github.nagyesta.yippeekijson.core.predicate;
+package com.github.nagyesta.yippeekijson.core.predicate.helper;
 
 import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
 import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
@@ -11,12 +11,12 @@ import java.util.stream.Collectors;
 /**
  * {@link Predicate} combining a collection of embedded predicates.
  */
-public abstract class CombiningPredicate implements Predicate<Object> {
+public abstract class CombiningPredicateSupport implements Predicate<Object> {
 
     private final List<Predicate<Object>> wrappedPredicates;
 
-    public CombiningPredicate(@NonNull final Collection<Map<String, RawConfigParam>> fromPredicates,
-                              @NonNull final FunctionRegistry functionRegistry) {
+    public CombiningPredicateSupport(@NonNull final Collection<Map<String, RawConfigParam>> fromPredicates,
+                                     @NonNull final FunctionRegistry functionRegistry) {
         wrappedPredicates = fromPredicates.stream()
                 .map(functionRegistry::lookupPredicate)
                 .collect(Collectors.toList());

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonCalculateRule.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonCalculateRule.java
@@ -34,11 +34,7 @@ public final class JsonCalculateRule extends AbstractJsonRule {
     public JsonCalculateRule(@NotNull final FunctionRegistry functionRegistry,
                              @NotNull final RawJsonRule jsonRule) {
         super(jsonRule.getOrder(), JsonPath.compile(jsonRule.getPath()));
-        if (jsonRule.getParams().containsKey(PARAM_PREDICATE)) {
-            this.predicate = functionRegistry.lookupPredicate(jsonRule.configParamMap(PARAM_PREDICATE));
-        } else {
-            this.predicate = new NotNullPredicate();
-        }
+        this.predicate = functionRegistry.lookupPredicate(jsonRule.configParamMap(PARAM_PREDICATE), new NotNullPredicate());
         this.numberFunction = functionRegistry.lookupFunction(jsonRule.configParamMap(PARAM_NUMBER_FUNCTION));
     }
 

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonDeleteFromMapRule.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonDeleteFromMapRule.java
@@ -2,7 +2,9 @@ package com.github.nagyesta.yippeekijson.core.rule.impl;
 
 import com.github.nagyesta.yippeekijson.core.annotation.NamedRule;
 import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
+import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
 import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawJsonRule;
+import com.github.nagyesta.yippeekijson.core.rule.impl.helper.JsonMapRuleSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
@@ -24,8 +26,9 @@ import java.util.function.Predicate;
  * </ol>
  */
 @Slf4j
-public final class JsonDeleteFromMapRule extends JsonMapRule {
+public final class JsonDeleteFromMapRule extends JsonMapRuleSupport {
 
+    static final String PARAM_PREDICATE = "predicate";
     static final String RULE_NAME = "deleteFrom";
     static final String PARAM_KEEP_KEY = "keepKey";
     static final String PARAM_DELETE_KEY = "deleteKey";
@@ -43,8 +46,9 @@ public final class JsonDeleteFromMapRule extends JsonMapRule {
 
     @NamedRule(RULE_NAME)
     public JsonDeleteFromMapRule(@NotNull final FunctionRegistry functionRegistry,
+                                 @NotNull final JsonMapper jsonMapper,
                                  @NotNull final RawJsonRule jsonRule) {
-        super(functionRegistry, jsonRule, log);
+        super(functionRegistry, jsonMapper, jsonRule, log, PARAM_PREDICATE);
         if (jsonRule.getParams().containsKey(PARAM_KEEP_KEY)) {
             this.keepIfKeyMatches = Optional.of(functionRegistry.lookupPredicate(jsonRule.configParamMap(PARAM_KEEP_KEY)));
         } else {

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonDeleteRule.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonDeleteRule.java
@@ -1,7 +1,6 @@
 package com.github.nagyesta.yippeekijson.core.rule.impl;
 
 import com.github.nagyesta.yippeekijson.core.annotation.NamedRule;
-import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
 import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawJsonRule;
 import com.github.nagyesta.yippeekijson.core.rule.AbstractJsonRule;
 import com.jayway.jsonpath.DocumentContext;
@@ -18,8 +17,7 @@ public final class JsonDeleteRule extends AbstractJsonRule {
     static final String RULE_NAME = "delete";
 
     @NamedRule(RULE_NAME)
-    public JsonDeleteRule(@SuppressWarnings("unused") @NotNull final FunctionRegistry functionRegistry,
-                          @NotNull final RawJsonRule jsonRule) {
+    public JsonDeleteRule(@NotNull final RawJsonRule jsonRule) {
         super(jsonRule.getOrder(), JsonPath.compile(jsonRule.getPath()));
     }
 

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonReplaceMapRule.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonReplaceMapRule.java
@@ -2,7 +2,9 @@ package com.github.nagyesta.yippeekijson.core.rule.impl;
 
 import com.github.nagyesta.yippeekijson.core.annotation.NamedRule;
 import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
+import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
 import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawJsonRule;
+import com.github.nagyesta.yippeekijson.core.rule.impl.helper.JsonMapRuleSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,8 +16,9 @@ import java.util.function.Function;
  * {@link java.util.function.Predicate}.
  */
 @Slf4j
-public final class JsonReplaceMapRule extends JsonMapRule {
+public final class JsonReplaceMapRule extends JsonMapRuleSupport {
 
+    static final String PARAM_PREDICATE = "predicate";
     static final String RULE_NAME = "replaceMap";
     static final String PARAM_MAP_FUNCTION = "mapFunction";
 
@@ -23,8 +26,9 @@ public final class JsonReplaceMapRule extends JsonMapRule {
 
     @NamedRule(RULE_NAME)
     public JsonReplaceMapRule(@NotNull final FunctionRegistry functionRegistry,
+                              @NotNull final JsonMapper jsonMapper,
                               @NotNull final RawJsonRule jsonRule) {
-        super(functionRegistry, jsonRule, log);
+        super(functionRegistry, jsonMapper, jsonRule, log, PARAM_PREDICATE);
         this.mapFunction = functionRegistry.lookupFunction(jsonRule.configParamMap(PARAM_MAP_FUNCTION));
     }
 

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonReplaceRule.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonReplaceRule.java
@@ -30,11 +30,7 @@ public final class JsonReplaceRule extends AbstractJsonRule {
     public JsonReplaceRule(@NotNull final FunctionRegistry functionRegistry,
                            @NotNull final RawJsonRule jsonRule) {
         super(jsonRule.getOrder(), JsonPath.compile(jsonRule.getPath()));
-        if (jsonRule.getParams().containsKey(PARAM_PREDICATE)) {
-            this.predicate = functionRegistry.lookupPredicate(jsonRule.configParamMap(PARAM_PREDICATE));
-        } else {
-            this.predicate = new AnyStringPredicate();
-        }
+        this.predicate = functionRegistry.lookupPredicate(jsonRule.configParamMap(PARAM_PREDICATE), new AnyStringPredicate());
         this.stringFunction = functionRegistry.lookupFunction(jsonRule.configParamMap(PARAM_STRING_FUNCTION));
     }
 

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonValidationRule.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonValidationRule.java
@@ -1,0 +1,76 @@
+package com.github.nagyesta.yippeekijson.core.rule.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.nagyesta.yippeekijson.core.annotation.NamedRule;
+import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawJsonRule;
+import com.github.nagyesta.yippeekijson.core.rule.AbstractJsonRule;
+import com.github.nagyesta.yippeekijson.core.rule.strategy.TransformationControlStrategy;
+import com.github.nagyesta.yippeekijson.core.rule.strategy.ViolationStrategy;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.mapper.MappingException;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.ValidationMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.util.Assert;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * Defines a rule validating the nodes selected by the {@link JsonPath}.
+ */
+@Slf4j
+public class JsonValidationRule extends AbstractJsonRule {
+
+    static final String RULE_NAME = "validate";
+    static final String PARAM_SCHEMA = "schema";
+    static final String PARAM_ON_FAILURE = "onFailure";
+    static final String PARAM_ON_FAILURE_TRANSFORMATION = "transformation";
+    static final String PARAM_ON_FAILURE_VIOLATION = "violation";
+    static final String ROOT_NODE = "$";
+    private final Supplier<JsonSchema> schemaSupplier;
+    private final TransformationControlStrategy transformationControlStrategy;
+    private final ViolationStrategy violationStrategy;
+
+    @NamedRule(RULE_NAME)
+    public JsonValidationRule(@NotNull final FunctionRegistry functionRegistry,
+                              @NotNull final RawJsonRule jsonRule) {
+        super(jsonRule.getOrder(), JsonPath.compile(ROOT_NODE));
+        this.schemaSupplier = functionRegistry.lookupSupplier(jsonRule.configParamMap(PARAM_SCHEMA));
+        final Map<String, RawConfigParam> onMap = jsonRule.configParamMap(PARAM_ON_FAILURE);
+        Assert.isTrue(onMap.containsKey(PARAM_ON_FAILURE_TRANSFORMATION), "onFailure.transformation value is mandatory");
+        this.transformationControlStrategy = toEnum(onMap.get(PARAM_ON_FAILURE_TRANSFORMATION).asString(),
+                TransformationControlStrategy.values(), TransformationControlStrategy.class);
+        this.violationStrategy = toEnum(onMap.get(PARAM_ON_FAILURE_VIOLATION).asString(),
+                ViolationStrategy.values(), ViolationStrategy.class);
+    }
+
+    private static <T extends Enum<T>> T toEnum(final String value, final T[] values, final Class<T> clazz) {
+        return Arrays.stream(values)
+                .filter(c -> c.name().equalsIgnoreCase(value))
+                .findFirst().orElseThrow(()
+                        -> new IllegalArgumentException("Unknown " + clazz.getSimpleName() + " supplied: " + value));
+    }
+
+    @Override
+    public void accept(final DocumentContext documentContext) {
+        try {
+            final JsonNode rootNode = documentContext.read(ROOT_NODE, JsonNode.class);
+            final JsonSchema jsonSchema = this.schemaSupplier.get();
+            log.info("Validating " + ROOT_NODE);
+            final Set<ValidationMessage> violations = jsonSchema.validate(rootNode, rootNode, ROOT_NODE);
+            this.violationStrategy.accept(documentContext, violations);
+            this.transformationControlStrategy.accept(violations);
+        } catch (final MappingException e) {
+            log.error("Processing failed: " + e.getMessage(), e);
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/helper/JsonMapRuleSupport.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/rule/impl/helper/JsonMapRuleSupport.java
@@ -1,4 +1,4 @@
-package com.github.nagyesta.yippeekijson.core.rule.impl;
+package com.github.nagyesta.yippeekijson.core.rule.impl.helper;
 
 import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
 import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
@@ -14,22 +14,27 @@ import org.slf4j.Logger;
 import java.util.Map;
 import java.util.function.Predicate;
 
-public abstract class JsonMapRule extends AbstractJsonRule {
-    static final String PARAM_PREDICATE = "predicate";
+/**
+ * Rule allowing easier processing of Map types.
+ */
+public abstract class JsonMapRuleSupport extends AbstractJsonRule {
+
     private static final String ALL_CHILDREN_OF_ROOT = "$.[*]";
 
     private final Predicate<Object> predicate;
     private final JsonMapper jsonMapper;
     private final Logger log;
 
-    public JsonMapRule(@NotNull final FunctionRegistry functionRegistry,
-                       @NotNull final RawJsonRule jsonRule,
-                       @NotNull final Logger log) {
+    public JsonMapRuleSupport(@NotNull final FunctionRegistry functionRegistry,
+                              @NotNull final JsonMapper jsonMapper,
+                              @NotNull final RawJsonRule jsonRule,
+                              @NotNull final Logger log,
+                              @NotNull final String predicateName) {
         super(jsonRule.getOrder(), JsonPath.compile(jsonRule.getPath()));
         this.log = log;
-        this.jsonMapper = functionRegistry.jsonMapper();
-        if (jsonRule.getParams().containsKey(PARAM_PREDICATE)) {
-            this.predicate = functionRegistry.lookupPredicate(jsonRule.configParamMap(PARAM_PREDICATE));
+        this.jsonMapper = jsonMapper;
+        if (jsonRule.getParams().containsKey(predicateName)) {
+            this.predicate = functionRegistry.lookupPredicate(jsonRule.configParamMap(predicateName));
         } else {
             this.predicate = new NotNullPredicate();
         }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/rule/strategy/TransformationControlStrategy.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/rule/strategy/TransformationControlStrategy.java
@@ -1,0 +1,56 @@
+package com.github.nagyesta.yippeekijson.core.rule.strategy;
+
+import com.github.nagyesta.yippeekijson.core.exception.AbortTransformationException;
+import com.github.nagyesta.yippeekijson.core.exception.StopRuleProcessingException;
+import com.networknt.schema.ValidationMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Set;
+
+/**
+ * Defines certain strategies for the validation error handling on the rule chain level.
+ */
+@Slf4j
+public enum TransformationControlStrategy {
+    /**
+     * Aborts the processing of the file entirely withut producing an output file.
+     */
+    ABORT() {
+        public void accept(@NotNull final Set<ValidationMessage> violations) {
+            if (!CollectionUtils.isEmpty(violations)) {
+                throw new AbortTransformationException("Abort: JSON document is invalid. " + violations.size() + " violations found.");
+            }
+        }
+    },
+    /**
+     * Skips the rest of the rule processing of the file, handling the partial data we have as final result.
+     * Useful for saving validation errors right into the JSON.
+     */
+    SKIP_REST() {
+        public void accept(@NotNull final Set<ValidationMessage> violations) {
+            if (!CollectionUtils.isEmpty(violations)) {
+                throw new StopRuleProcessingException("Stop: JSON document is invalid. " + violations.size() + " violations found.");
+            }
+        }
+    },
+    /**
+     * Does nothing, the rule processing can continue regardless of the validation failures.
+     */
+    CONTINUE() {
+        @Override
+        public void accept(@NotNull final Set<ValidationMessage> violations) {
+            if (!CollectionUtils.isEmpty(violations)) {
+                log.info("Ignore: JSON document is invalid. " + violations.size() + " violations found.");
+            }
+        }
+    };
+
+    /**
+     * Evaluates the validation result and triggers a response if needed.
+     *
+     * @param violations The validation results.
+     */
+    public abstract void accept(@NotNull Set<ValidationMessage> violations);
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/rule/strategy/ViolationStrategy.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/rule/strategy/ViolationStrategy.java
@@ -1,0 +1,137 @@
+package com.github.nagyesta.yippeekijson.core.rule.strategy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
+import com.networknt.schema.ValidationMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Defines the possible strategies to handle violations.
+ */
+@Slf4j
+public enum ViolationStrategy {
+    /**
+     * Logs the findings to the default log.
+     */
+    LOG_ONLY() {
+        @Override
+        public void accept(@NotNull final DocumentContext documentContext,
+                           @NotNull final Set<ValidationMessage> violations) {
+            if (CollectionUtils.isEmpty(violations)) {
+                return;
+            }
+            violations.stream()
+                    .map(ValidationMessage::getMessage)
+                    .forEach(log::error);
+        }
+    },
+    /**
+     * Comments the validation results into the JSON itself. Finds the closest possible object by stepping up on
+     * the hierarchy of the node that failed to mitigate that some nodes cannot contain fields.
+     */
+    COMMENT_JSON() {
+        @Override
+        public void accept(@NotNull final DocumentContext documentContext,
+                           @NotNull final Set<ValidationMessage> violations) {
+            if (CollectionUtils.isEmpty(violations)) {
+                return;
+            }
+            violations.forEach(validationMessage -> {
+                final String path = validationMessage.getPath();
+                Optional<JsonPath> target = findClosestObjectNode(documentContext, path);
+                if (target.isEmpty()) {
+                    log.error("Cannot append node to: " + validationMessage.getPath());
+                    log.error(validationMessage.getMessage());
+                } else {
+                    final JsonPath jsonPath = target.get();
+                    final Map<String, Object> map = documentContext.read(jsonPath, JsonMapper.MapTypeRef.INSTANCE);
+                    if (!map.containsKey(VALIDATION_NODE)) {
+                        documentContext.put(jsonPath, VALIDATION_NODE, new ArrayList<>());
+                    }
+                    documentContext.add(JsonPath.compile(jsonPath.getPath() + DOT + VALIDATION_NODE),
+                            Map.of(PATH_FIELD_NAME, validationMessage.getPath(),
+                                    MESSAGE_FIELD_NAME, validationMessage.getMessage()));
+                }
+            });
+        }
+
+        private Optional<JsonPath> findClosestObjectNode(@NotNull final DocumentContext documentContext,
+                                                         @NotNull final String path) {
+            Optional<JsonPath> jsonPath = Optional.ofNullable(safeCompile(path));
+            if (jsonPath.isPresent() && isNotAnObject(documentContext, jsonPath.get())) {
+                jsonPath = continueUntilRootFound(documentContext, path);
+            }
+            return jsonPath;
+        }
+
+        private Optional<JsonPath> continueUntilRootFound(@NotNull final DocumentContext documentContext,
+                                                          @NotNull final String path) {
+            Optional<JsonPath> jsonPath;
+            if (ROOT_NODE.equalsIgnoreCase(path)) {
+                jsonPath = Optional.empty();
+            } else {
+                jsonPath = findClosestObjectNode(documentContext, StringUtils.substringBeforeLast(path, DOT));
+            }
+            return jsonPath;
+        }
+
+        private boolean isNotAnObject(@NotNull final DocumentContext documentContext,
+                                      @NotNull final JsonPath jsonPath) {
+            try {
+                final JsonNode read = documentContext.read(jsonPath, JsonNode.class);
+                return !read.isObject();
+            } catch (final PathNotFoundException e) {
+                return true;
+            }
+        }
+
+        private JsonPath safeCompile(@NotNull final String path) {
+            try {
+                return JsonPath.compile(path);
+            } catch (final Exception e) {
+                log.error(e.getMessage(), e);
+                return null;
+            }
+        }
+    },
+
+    /**
+     * Ignores the output.
+     */
+    IGNORE() {
+        @Override
+        public void accept(@NotNull final DocumentContext documentContext,
+                           @NotNull final Set<ValidationMessage> violations) {
+            if (CollectionUtils.isEmpty(violations)) {
+                return;
+            }
+            log.info("Suppress: JSON document is invalid. " + violations.size() + " violations found.");
+        }
+    };
+
+    static final String DOT = ".";
+    static final String ROOT_NODE = "$";
+    static final String VALIDATION_NODE = "$_yippee-schema-violation";
+    static final String MESSAGE_FIELD_NAME = "message";
+    static final String PATH_FIELD_NAME = "path";
+
+    /**
+     * Evaluates the validation result and triggers a response if needed.
+     *
+     * @param documentContext The document we are processing.
+     * @param violations      The validation results.
+     */
+    public abstract void accept(@NotNull DocumentContext documentContext,
+                                @NotNull Set<ValidationMessage> violations);
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/ConvertingSupplier.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/ConvertingSupplier.java
@@ -1,0 +1,44 @@
+package com.github.nagyesta.yippeekijson.core.supplier;
+
+import com.github.nagyesta.yippeekijson.core.annotation.EmbedParam;
+import com.github.nagyesta.yippeekijson.core.annotation.NamedSupplier;
+import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
+import lombok.NonNull;
+
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * {@link Supplier} returning the result of a {@link Function} allied on the result of a {@link String} {@link Supplier}.
+ */
+public final class ConvertingSupplier implements Supplier<Object> {
+
+    static final String NAME = "converting";
+
+    private final Supplier<String> stringSupplier;
+    private final Function<String, ?> converterFunction;
+
+    @NamedSupplier(NAME)
+    public ConvertingSupplier(@EmbedParam @NonNull final Map<String, RawConfigParam> stringSource,
+                              @EmbedParam @NonNull final Map<String, RawConfigParam> converter,
+                              @NonNull final FunctionRegistry functionRegistry) {
+        this.stringSupplier = functionRegistry.lookupSupplier(stringSource);
+        this.converterFunction = functionRegistry.lookupFunction(converter);
+    }
+
+    @Override
+    public Object get() {
+        return converterFunction.apply(stringSupplier.get());
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ConvertingSupplier.class.getSimpleName() + "[", "]")
+                .add("stringSupplier=" + stringSupplier)
+                .add("converterFunction=" + converterFunction)
+                .toString();
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/FileContentSupplier.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/FileContentSupplier.java
@@ -1,0 +1,56 @@
+package com.github.nagyesta.yippeekijson.core.supplier;
+
+import com.github.nagyesta.yippeekijson.core.annotation.NamedSupplier;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
+import com.github.nagyesta.yippeekijson.core.exception.AbortTransformationException;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.StringJoiner;
+import java.util.function.Supplier;
+
+/**
+ * {@link Supplier} returning the whole content of a {@link java.io.File}.
+ */
+@Slf4j
+public final class FileContentSupplier implements Supplier<String> {
+
+    static final String NAME = "file";
+
+    private final String path;
+    private final Charset charset;
+
+    @NamedSupplier(NAME)
+    public FileContentSupplier(@ValueParam @NonNull final String path,
+                               @ValueParam @Nullable final String charset) {
+        this.path = path;
+        this.charset = Optional.ofNullable(charset)
+                .map(Charset::forName)
+                .orElse(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public String get() {
+        try {
+            return FileUtils.readFileToString(new File(path), this.charset);
+        } catch (final IOException e) {
+            log.error("Failed to open file: '" + path + "' due to:" + e.getMessage(), e);
+            throw new AbortTransformationException("Failed to open file: '" + path + "' due to:" + e.getMessage());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", FileContentSupplier.class.getSimpleName() + "[", "]")
+                .add("path='" + path + "'")
+                .add("charset='" + charset + "'")
+                .toString();
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/HttpResourceContentSupplier.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/HttpResourceContentSupplier.java
@@ -1,0 +1,49 @@
+package com.github.nagyesta.yippeekijson.core.supplier;
+
+import com.github.nagyesta.yippeekijson.core.annotation.MapParam;
+import com.github.nagyesta.yippeekijson.core.annotation.NamedSupplier;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
+import com.github.nagyesta.yippeekijson.core.http.HttpClient;
+import com.github.nagyesta.yippeekijson.core.http.HttpRequestContext;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.function.Supplier;
+
+/**
+ * {@link Supplier} returning the whole content of a web resource.
+ */
+@Slf4j
+public final class HttpResourceContentSupplier implements Supplier<String> {
+
+    static final String NAME = "httpResource";
+
+    private final HttpRequestContext httpRequestContext;
+    private final HttpClient httpClient;
+
+    @NamedSupplier(NAME)
+    public HttpResourceContentSupplier(@ValueParam @NonNull final String uri,
+                                       @ValueParam @Nullable final String httpMethod,
+                                       @MapParam @Nullable final Map<String, String> httpHeaders,
+                                       @ValueParam @Nullable final String charset,
+                                       @NonNull final HttpClient httpClient) {
+        this.httpRequestContext = new HttpRequestContext(uri, httpMethod, httpHeaders, charset);
+        this.httpClient = httpClient;
+
+    }
+
+    @Override
+    public String get() {
+        return httpClient.fetch(httpRequestContext);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", HttpResourceContentSupplier.class.getSimpleName() + "[", "]")
+                .add("httpRequestContext=" + httpRequestContext)
+                .toString();
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/JsonSchemaSupplier.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/JsonSchemaSupplier.java
@@ -1,0 +1,59 @@
+package com.github.nagyesta.yippeekijson.core.supplier;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.nagyesta.yippeekijson.core.annotation.EmbedParam;
+import com.github.nagyesta.yippeekijson.core.annotation.NamedSupplier;
+import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
+import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
+import com.github.nagyesta.yippeekijson.core.exception.AbortTransformationException;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.function.Supplier;
+
+@Slf4j
+public class JsonSchemaSupplier implements Supplier<JsonSchema> {
+
+    static final String NAME = "jsonSchema";
+
+    private final Supplier<String> sourceSupplier;
+    private final JsonMapper jsonMapper;
+
+    @NamedSupplier(NAME)
+    public JsonSchemaSupplier(@EmbedParam @NonNull final Map<String, RawConfigParam> source,
+                              @NonNull final JsonMapper jsonMapper,
+                              @NonNull final FunctionRegistry functionRegistry) {
+        this.jsonMapper = jsonMapper;
+        this.sourceSupplier = functionRegistry.lookupSupplier(source);
+    }
+
+    @Override
+    public JsonSchema get() {
+        final ObjectMapper objectMapper = jsonMapper.objectMapper();
+        try {
+            final JsonNode schemaNode = objectMapper.readTree(sourceSupplier.get());
+            JsonSchemaFactory factory = JsonSchemaFactory
+                    .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
+                    .objectMapper(objectMapper)
+                    .build();
+            return factory.getSchema(schemaNode);
+        } catch (final Exception e) {
+            log.error("Failed to supply schema: " + e.getMessage(), e);
+            throw new AbortTransformationException("Failed to supply schema: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", JsonSchemaSupplier.class.getSimpleName() + "[", "]")
+                .add("sourceSupplier=" + sourceSupplier)
+                .toString();
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/SchemaStoreSchemaContentSupplier.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/SchemaStoreSchemaContentSupplier.java
@@ -1,0 +1,92 @@
+package com.github.nagyesta.yippeekijson.core.supplier;
+
+import com.github.nagyesta.yippeekijson.core.annotation.NamedSupplier;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
+import com.github.nagyesta.yippeekijson.core.config.entities.SchemaStoreConfig;
+import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
+import com.github.nagyesta.yippeekijson.core.http.HttpClient;
+import com.github.nagyesta.yippeekijson.core.http.HttpRequestContext;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.util.Assert;
+
+import java.net.URI;
+import java.util.*;
+import java.util.function.Supplier;
+
+@Slf4j
+public class SchemaStoreSchemaContentSupplier implements Supplier<String> {
+
+    private static final String NAME = "schemaStore";
+
+    private final JsonMapper jsonMapper;
+    private final String schemaName;
+    private final HttpClient httpClient;
+    private final SchemaStoreConfig schemaStoreConfig;
+
+    @NamedSupplier(NAME)
+    public SchemaStoreSchemaContentSupplier(@ValueParam @NonNull final String schemaName,
+                                            @NonNull final HttpClient httpClient,
+                                            @NonNull final JsonMapper jsonMapper,
+                                            @NonNull final SchemaStoreConfig schemaStoreConfig) {
+        this.jsonMapper = jsonMapper;
+        this.schemaName = schemaName;
+        this.httpClient = httpClient;
+        this.schemaStoreConfig = schemaStoreConfig;
+    }
+
+    @Override
+    public String get() {
+        final Optional<URI> uri = Optional.ofNullable(fetchDescriptor().get(schemaName));
+        Assert.isTrue(uri.isPresent(), "Failed to find URI for SchemaStore schema: '" + schemaName + "'");
+        final HttpRequestContext requestContext = HttpRequestContext.builder()
+                .uri(uri.get().toString())
+                .build();
+        return httpClient.fetch(requestContext);
+    }
+
+    private Map<String, URI> fetchDescriptor() {
+        final HttpRequestContext requestContext = HttpRequestContext.builder()
+                .uri(schemaStoreConfig.getCatalogUri())
+                .build();
+        final String schemaStoreCatalog = httpClient.fetch(requestContext);
+        Map<String, URI> schemaCatalog = new HashMap<>();
+        try {
+            final List<Object> result = JsonPath.parse(schemaStoreCatalog,
+                    Configuration.builder().options(Option.ALWAYS_RETURN_LIST).build())
+                    .read(schemaStoreConfig.getSchemaArrayPath());
+            result.forEach(schemaItem -> {
+                final Map<String, Object> map = jsonMapper.mapTo(schemaItem, JsonMapper.MapTypeRef.INSTANCE);
+                try {
+                    schemaCatalog.put(nonNullString(map.get(schemaStoreConfig.getMappingNameKey())),
+                            URI.create(nonNullString(map.get(schemaStoreConfig.getMappingUrlKey()))));
+                } catch (final Exception e) {
+                    log.warn("Invalid schema item found: " + map);
+                }
+            });
+        } catch (final Exception e) {
+            log.error(e.getMessage(), e);
+        }
+        return schemaCatalog;
+    }
+
+    @NotNull
+    private String nonNullString(final Object obj) {
+        Assert.notNull(obj, "object value cannot be null.");
+        final String string = StringUtils.trimToNull(obj.toString());
+        Assert.notNull(string, "string value cannot be null.");
+        return string;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", SchemaStoreSchemaContentSupplier.class.getSimpleName() + "[", "]")
+                .add("schemaName='" + schemaName + "'")
+                .toString();
+    }
+}

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/StaticJsonSupplier.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/StaticJsonSupplier.java
@@ -1,8 +1,8 @@
 package com.github.nagyesta.yippeekijson.core.supplier;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedSupplier;
-import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
+import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
 import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
 import lombok.NonNull;
@@ -11,22 +11,21 @@ import java.util.StringJoiner;
 import java.util.function.Supplier;
 
 /**
- * {@link Supplier} matching a static JSON {@link String}.
+ * {@link Supplier} returning a static JSON {@link String}.
  */
 public final class StaticJsonSupplier implements Supplier<Object> {
 
     static final String NAME = "staticJson";
-    static final String PARAM_VALUE = "value";
 
     private final String value;
     private final Object json;
 
     @NamedSupplier(NAME)
-    public StaticJsonSupplier(@MethodParam(PARAM_VALUE) @NonNull final String value,
-                              @NonNull final FunctionRegistry functionRegistry) {
+    public StaticJsonSupplier(@ValueParam @NonNull final String value,
+                              @NonNull final JsonMapper jsonMapper) {
         this.value = value;
         try {
-            this.json = JsonPath.parse(value, functionRegistry.jsonMapper().parserConfiguration()).json();
+            this.json = JsonPath.parse(value, jsonMapper.parserConfiguration()).json();
         } catch (final InvalidJsonException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }

--- a/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/StaticStringSupplier.java
+++ b/src/main/java/com/github/nagyesta/yippeekijson/core/supplier/StaticStringSupplier.java
@@ -1,24 +1,23 @@
 package com.github.nagyesta.yippeekijson.core.supplier;
 
-import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedSupplier;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
 import lombok.NonNull;
 
 import java.util.StringJoiner;
 import java.util.function.Supplier;
 
 /**
- * {@link Supplier} matching a static {@link String}.
+ * {@link Supplier} returning a static {@link String}.
  */
 public final class StaticStringSupplier implements Supplier<String> {
 
     static final String NAME = "staticString";
-    static final String PARAM_VALUE = "value";
 
     private final String value;
 
     @NamedSupplier(NAME)
-    public StaticStringSupplier(@MethodParam(PARAM_VALUE) @NonNull final String value) {
+    public StaticStringSupplier(@ValueParam @NonNull final String value) {
         this.value = value;
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,14 +1,26 @@
+#
+# App
+#
 # suppress inspection "SpringBootApplicationProperties"
 application.version=${version}
 # suppress inspection "SpringBootApplicationProperties"
 application.formatted-version=\\ (v${version})
 # suppress inspection "SpringBootApplicationProperties"
 application.title=Yippee-Ki-JON
-
+#
+# Logging
+#
 logging.level.root=WARN
 logging.level.org.springframework=WARN
+logging.level.com.networknt.schema=WARN
 logging.level.com.github.nagyesta.yippeekijson.core.control=INFO
-
+# suppress inspection "UnusedMessageFormatParameter"
+logging.exception-conversion-word=%ex{2}
+logging.pattern.level=%5p
+logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(\${logging.pattern.level}) %clr(%-40.40logger{29}){cyan} %clr(:){faint} %m%n\${logging.exception-conversion-word}
+#
+# Runtime
+#
 # suppress inspection "SpringBootApplicationProperties"
 yippee.config=actions.yml
 # suppress inspection "SpringBootApplicationProperties"
@@ -18,6 +30,8 @@ yippee.input=./
 # suppress inspection "SpringBootApplicationProperties"
 yippee.allow-overwrite=true
 # suppress inspection "SpringBootApplicationProperties"
+yippee.relaxed-yml-schema=false
+# suppress inspection "SpringBootApplicationProperties"
 yippee.includes[0]=*.json
 # suppress inspection "SpringBootApplicationProperties"
 yippee.excludes[0]=
@@ -25,3 +39,25 @@ yippee.excludes[0]=
 yippee.output=
 # suppress inspection "SpringBootApplicationProperties"
 yippee.output-directory=
+#
+# SchemaStore
+#
+# suppress inspection "SpringBootApplicationProperties"
+additional.schema-store.catalog-uri=https://www.schemastore.org/api/json/catalog.json
+# suppress inspection "SpringBootApplicationProperties"
+additional.schema-store.schema-array-path=\\\$.schemas[*]
+# suppress inspection "SpringBootApplicationProperties"
+additional.schema-store.mapping-name-key=name
+# suppress inspection "SpringBootApplicationProperties"
+additional.schema-store.mapping-url-key=url
+#
+# HTTP
+#
+# suppress inspection "SpringBootApplicationProperties"
+additional.http.user-agent=\${application.title}/\${application.version} (Java \${java.version}) (\${os.name} \${os.version})
+# suppress inspection "SpringBootApplicationProperties"
+additional.http.add-default-headers=true
+# suppress inspection "SpringBootApplicationProperties"
+additional.http.min-success-status=200
+# suppress inspection "SpringBootApplicationProperties"
+additional.http.max-success-status=299

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ application.version=${version}
 # suppress inspection "SpringBootApplicationProperties"
 application.formatted-version=\\ (v${version})
 # suppress inspection "SpringBootApplicationProperties"
-application.title=Yippee-Ki-JON
+application.title=Yippee-Ki-JSON
 #
 # Logging
 #
@@ -37,6 +37,8 @@ yippee.includes[0]=*.json
 yippee.excludes[0]=
 # suppress inspection "SpringBootApplicationProperties"
 yippee.output=
+# suppress inspection "SpringBootApplicationProperties"
+yippee.charset=UTF-8
 # suppress inspection "SpringBootApplicationProperties"
 yippee.output-directory=
 #

--- a/src/main/resources/help.txt
+++ b/src/main/resources/help.txt
@@ -13,7 +13,7 @@ SYNOPSIS
             [--yippee.includes[0]=pattern] [--yippee.includes[1]=pattern] ... [--yippee.includes[N]=pattern]
             [--yippee.excludes[0]=pattern] [--yippee.excludes[1]=pattern] ... [--yippee.excludes[N]=pattern]
             [--yippee.allow-overwrite={true|false}] [--yippee.relaxed-yml-schema=={true|false}]
-            --yippee.output-directory=directory
+            --yippee.output-directory=directory [--yippee.charset=charset]
 
 DESCRIPTION
     Yippee-Ki-JSON is a Lightweight JSON manipulation application using Spring Boot and JSON Path as core.
@@ -89,6 +89,10 @@ OPTIONS
         --yippee.output-directory
             Output directory path.
 
+        --yippee.charset
+            Default character set used during parsing.
+            Default: UTF-8
+
     Spring Boot options
         All generic Spring Boot options are supported. Please find a few useful ones below.
 
@@ -111,6 +115,40 @@ OPTIONS
 
         --logging.level.com.github.nagyesta.yippeekijson={DEBUG|INFO|WARN|ERROR}
             Set logging of the Yippee-Ki-JSON codebase to DEBUG/INFO/WARN/ERROR.
+
+    SchemaStore integration options
+        --additional.schema-store.catalog-uri
+            The URI of the SchemaStore catalog JSON.
+            Default: https://www.schemastore.org/api/json/catalog.json
+
+        --additional.schema-store.schema-array-path
+            The JSON Path we will use to get the list/array items of the catalog.
+            Default: $.schemas[*]
+
+        --additional.schema-store.mapping-name-key
+            The key referencing the name of the schema item.
+            Default: name
+
+        --additional.schema-store.mapping-url-key
+            The key referencing the URI of the schema item.
+            Default: url
+
+    HTTP Client options
+        --additional.http.user-agent
+            The value of the user-agent HTTP header.
+            Default: Yippee-Ki-JSON/${application.version} (Java ${java.version}) (${os.name} ${os.version})
+
+        --additional.http.add-default-headers
+            Boolean telling the app to add the default HTTP headers automatically.
+            Default: true
+
+        --additional.http.min-success-status
+            The minimum (inclusive) HTTP status code value we should consider as successful.
+            Default: 200
+
+        --additional.http.max-success-status
+            The maximum (inclusive) HTTP status code value we should consider as successful.
+            Default: 299
 
 EXIT STATUS
         0       Successful program execution (not necessarily successful output generation).

--- a/src/main/resources/help.txt
+++ b/src/main/resources/help.txt
@@ -12,7 +12,8 @@ SYNOPSIS
     java -jar yippee-ki-json.jar [--yippee.config=file] --yippee.action=action [--yippee.input=directory]
             [--yippee.includes[0]=pattern] [--yippee.includes[1]=pattern] ... [--yippee.includes[N]=pattern]
             [--yippee.excludes[0]=pattern] [--yippee.excludes[1]=pattern] ... [--yippee.excludes[N]=pattern]
-            [--yippee.allow-overwrite={true|false}] --yippee.output-directory=directory
+            [--yippee.allow-overwrite={true|false}] [--yippee.relaxed-yml-schema=={true|false}]
+            --yippee.output-directory=directory
 
 DESCRIPTION
     Yippee-Ki-JSON is a Lightweight JSON manipulation application using Spring Boot and JSON Path as core.
@@ -68,6 +69,10 @@ OPTIONS
         --yippee.allow-overwrite
             Specifies whether we allow overwriting existing outputs.
             Default: true
+
+        --yippee.relaxed-yml-schema
+            Allows suppression of YML configuration related schema violations.
+            Default: false
 
         --yippee.includes[0]
         --yippee.includes[1]..

--- a/src/test/java/com/github/nagyesta/yippeekijson/YippeeKiJsonApplicationTests.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/YippeeKiJsonApplicationTests.java
@@ -90,7 +90,7 @@ class YippeeKiJsonApplicationTests {
     @Test
     @SuppressWarnings("checkstyle:MagicNumber")
     void testParseConfigFile() throws ConfigParseException {
-        final JsonActions parse = actionConfigParser.parse(this.getClass().getResourceAsStream("/yaml/example.yml"));
+        final JsonActions parse = actionConfigParser.parse(this.getClass().getResourceAsStream("/yaml/example.yml"), false);
         Assertions.assertNotNull(parse);
         Assertions.assertEquals(2, parse.getActions().size());
         Assertions.assertEquals(3, parse.getActions().get("filter").getRules().size());

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/InjectableBeanSupportTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/InjectableBeanSupportTest.java
@@ -1,0 +1,144 @@
+package com.github.nagyesta.yippeekijson.core.config.parser.impl;
+
+import com.github.nagyesta.yippeekijson.core.annotation.Injectable;
+import com.github.nagyesta.yippeekijson.core.config.entities.HttpConfig;
+import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
+import com.github.nagyesta.yippeekijson.core.http.HttpClient;
+import com.github.nagyesta.yippeekijson.core.http.impl.DefaultHttpClient;
+import com.google.common.collect.ImmutableMap;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
+
+import javax.inject.Named;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Slf4j
+class InjectableBeanSupportTest {
+
+    public static final String HTTP_CLIENT_1 = "httpClient1";
+    public static final String HTTP_CLIENT_2 = "httpClient2";
+    public static final String JSON_MAPPER = "jsonMapper";
+    private static final DefaultHttpClient FIRST_HTTP_CLIENT_INSTANCE = new DefaultHttpClient(HttpConfig.builder().build());
+    private static final DefaultHttpClient SECOND_HTTP_CLIENT_INSTANCE = new DefaultHttpClient(HttpConfig.builder().build());
+    private static final JsonMapperImpl JSON_MAPPER_INSTANCE = new JsonMapperImpl();
+
+    private static InjectableBeanSupport underTest;
+
+    @SuppressWarnings("RedundantThrows")
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        when(applicationContext.getBeansWithAnnotation(Injectable.class))
+                .thenReturn(ImmutableMap.<String, Object>builder()
+                        .put(HTTP_CLIENT_1, FIRST_HTTP_CLIENT_INSTANCE)
+                        .put(HTTP_CLIENT_2, SECOND_HTTP_CLIENT_INSTANCE)
+                        .put(JSON_MAPPER, JSON_MAPPER_INSTANCE)
+                        .build());
+        underTest = new InjectableBeanSupport(log) {
+            @Override
+            protected void afterInitialized() {
+                //noop
+            }
+        };
+        underTest.setApplicationContext(applicationContext);
+        Assertions.assertDoesNotThrow(() -> underTest.afterPropertiesSet());
+    }
+
+    private static Stream<Arguments> validParameterProvider() throws NoSuchMethodException {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(constructor(JsonMapper.class, HttpClient.class, HttpClient.class), 0, JSON_MAPPER_INSTANCE))
+                .add(Arguments.of(constructor(JsonMapper.class, HttpClient.class, HttpClient.class), 1, FIRST_HTTP_CLIENT_INSTANCE))
+                .add(Arguments.of(constructor(JsonMapper.class, HttpClient.class, HttpClient.class), 2, SECOND_HTTP_CLIENT_INSTANCE))
+                .add(Arguments.of(constructor(HttpClient.class, HttpClient.class), 0, SECOND_HTTP_CLIENT_INSTANCE))
+                .add(Arguments.of(constructor(HttpClient.class, HttpClient.class), 1, SECOND_HTTP_CLIENT_INSTANCE))
+                .add(Arguments.of(constructor(JsonMapper.class, HttpClient.class), 1, FIRST_HTTP_CLIENT_INSTANCE))
+                .build();
+    }
+
+    @NotNull
+    private static Constructor<ConstructorProvider> constructor(final Class<?>... params) throws NoSuchMethodException {
+        return ConstructorProvider.class.getDeclaredConstructor(params);
+    }
+
+    @ParameterizedTest
+    @MethodSource("validParameterProvider")
+    void testValidCandidateOfShouldReturnExistingCandidates(final Constructor<ConstructorProvider> constructor,
+                                                            final int parameterIndex,
+                                                            final Object expected) {
+        //given
+        Parameter parameter = constructor.getParameters()[parameterIndex];
+
+        //when
+        final Object actual = underTest.validCandidateOf(constructor, parameter);
+
+        //then
+        Assertions.assertSame(expected, actual);
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {JsonMapper.class, HttpClient.class})
+    void testHasCandidateForShouldReturnTrueForExistingCandidates(final Class<?> clazz) {
+        //given
+
+        //when
+        final boolean actual = underTest.hasCandidateFor(clazz);
+
+        //then
+        Assertions.assertTrue(actual);
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {JsonMapperImpl.class, DefaultHttpClient.class})
+    void testHasCandidateForShouldReturnFalseForUnknownCandidates(final Class<?> clazz) {
+        //given
+
+        //when
+        final boolean actual = underTest.hasCandidateFor(clazz);
+
+        //then
+        Assertions.assertFalse(actual);
+    }
+
+    @Test
+    void testValidCandidateOfShouldThrowExceptionWhenCandidateNamesAreAmbiguous() throws NoSuchMethodException {
+        //given
+        final Constructor<ConstructorProvider> constructor = constructor(HttpClient.class);
+        final Parameter parameter = constructor.getParameters()[0];
+
+        //when + then exception
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.validCandidateOf(constructor, parameter));
+    }
+
+    @SuppressWarnings("unused")
+    private static final class ConstructorProvider {
+
+        private ConstructorProvider(final JsonMapper jsonMapper,
+                                    @Named final HttpClient httpClient1,
+                                    @Qualifier final HttpClient httpClient2) {
+        }
+
+        private ConstructorProvider(@Named("httpClient2") final HttpClient httpClient,
+                                    @Qualifier final HttpClient httpClient2) {
+        }
+
+        private ConstructorProvider(final HttpClient httpClient) {
+        }
+
+        private ConstructorProvider(final JsonMapper jsonMapper, final HttpClient httpClient1) {
+        }
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/JsonRuleRegistryImplTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/JsonRuleRegistryImplTest.java
@@ -1,5 +1,6 @@
 package com.github.nagyesta.yippeekijson.core.config.parser.impl;
 
+import com.github.nagyesta.yippeekijson.core.annotation.Injectable;
 import com.github.nagyesta.yippeekijson.core.annotation.NamedRule;
 import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
 import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawJsonRule;
@@ -13,15 +14,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.context.ApplicationContext;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class JsonRuleRegistryImplTest {
 
+    static final String FUNCTION_REGISTRY = "functionRegistry";
     private static final String DELETE = "delete";
     private static final String PATH = "$..a";
     private static final String FAILING = "failing";
@@ -81,10 +86,18 @@ class JsonRuleRegistryImplTest {
     void testConstructorShouldFailIfWrongClassProvided(final List<Class<? extends JsonRule>> rules,
                                                        final Class<? extends Exception> exception) {
         //given
-        final FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        final FunctionRegistry functionRegistry = new FunctionRegistryImpl(
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        final ApplicationContext applicationContext = mock(ApplicationContext.class);
+        when(applicationContext.getBeansWithAnnotation(Injectable.class))
+                .thenReturn(Map.of(FUNCTION_REGISTRY, functionRegistry));
 
         //when + then exception
-        Assertions.assertThrows(exception, () -> new JsonRuleRegistryImpl(functionRegistry, rules));
+        Assertions.assertThrows(exception, () -> {
+            final JsonRuleRegistryImpl underTest = new JsonRuleRegistryImpl(functionRegistry, rules);
+            underTest.setApplicationContext(applicationContext);
+            underTest.afterPropertiesSet();
+        });
     }
 
     @Test
@@ -107,10 +120,17 @@ class JsonRuleRegistryImplTest {
 
     @ParameterizedTest
     @MethodSource("invalidRuleProvider")
-    void testNewInstanceFromShouldFailForInvalidInput(final RawJsonRule source, final Class<? extends Exception> exception) {
+    void testNewInstanceFromShouldFailForInvalidInput(final RawJsonRule source, final Class<? extends Exception> exception)
+            throws Exception {
         //given
-        final FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        final FunctionRegistry functionRegistry = new FunctionRegistryImpl(
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        final ApplicationContext applicationContext = mock(ApplicationContext.class);
+        when(applicationContext.getBeansWithAnnotation(Injectable.class))
+                .thenReturn(Map.of(FUNCTION_REGISTRY, functionRegistry));
         final JsonRuleRegistryImpl underTest = new JsonRuleRegistryImpl(functionRegistry, Collections.emptyList());
+        underTest.setApplicationContext(applicationContext);
+        underTest.afterPropertiesSet();
         underTest.registerRuleClass(JsonDeleteRule.class);
         underTest.registerRuleClass(FailingRule.class);
 

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/ParameterContextTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/ParameterContextTest.java
@@ -1,0 +1,54 @@
+package com.github.nagyesta.yippeekijson.core.config.parser.impl;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static com.github.nagyesta.yippeekijson.core.test.params.ParamAnnotationHolder.*;
+
+class ParameterContextTest {
+
+    private static Stream<Arguments> validValueProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(ParameterContext.UseCase.VALUE, PARAM_DIFFERENT_NAME, PARAM_DIFFERENT_NAME_EXPECTED, false, false))
+                .add(Arguments.of(ParameterContext.UseCase.VALUE, PARAM_SAME_NAME, PARAM_SAME_NAME, false, false))
+                .add(Arguments.of(ParameterContext.UseCase.VALUE, PARAM_JAVAX_NULLABLE, PARAM_JAVAX_NULLABLE, false, true))
+                .add(Arguments.of(ParameterContext.UseCase.VALUE, PARAM_SPRING_NULLABLE, PARAM_SPRING_NULLABLE_EXPECTED, false, true))
+                .add(Arguments.of(ParameterContext.UseCase.VALUE, PARAM_NAMED_LIST, PARAM_NAMED_LIST_EXPECTED, true, false))
+                .add(Arguments.of(ParameterContext.UseCase.MAP, PARAM_DIFFERENT_NAME, PARAM_DIFFERENT_NAME_EXPECTED, false, false))
+                .add(Arguments.of(ParameterContext.UseCase.MAP, PARAM_SAME_NAME, PARAM_SAME_NAME, false, false))
+                .add(Arguments.of(ParameterContext.UseCase.MAP, PARAM_JAVAX_NULLABLE, PARAM_JAVAX_NULLABLE, false, true))
+                .add(Arguments.of(ParameterContext.UseCase.MAP, PARAM_SPRING_NULLABLE, PARAM_SPRING_NULLABLE_EXPECTED, false, true))
+                .add(Arguments.of(ParameterContext.UseCase.MAP, PARAM_NAMED_LIST, PARAM_NAMED_LIST_EXPECTED, true, false))
+                .add(Arguments.of(ParameterContext.UseCase.EMBEDDED, PARAM_DIFFERENT_NAME, PARAM_DIFFERENT_NAME_EXPECTED, false, false))
+                .add(Arguments.of(ParameterContext.UseCase.EMBEDDED, PARAM_SAME_NAME, PARAM_SAME_NAME, false, false))
+                .add(Arguments.of(ParameterContext.UseCase.EMBEDDED, PARAM_JAVAX_NULLABLE, PARAM_JAVAX_NULLABLE, false, true))
+                .add(Arguments.of(ParameterContext.UseCase.EMBEDDED, PARAM_SPRING_NULLABLE, PARAM_SPRING_NULLABLE_EXPECTED, false, true))
+                .add(Arguments.of(ParameterContext.UseCase.EMBEDDED, PARAM_NAMED_LIST, PARAM_NAMED_LIST_EXPECTED, true, false))
+                .build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("validValueProvider")
+    void testConstructorShouldParseValidParams(final ParameterContext.UseCase useCase,
+                                               final String paramName,
+                                               final String expectedName,
+                                               final boolean expectedCollectionType,
+                                               final boolean expectedNullable) {
+        //given
+
+        //when
+        ParameterContext actual = getParamContextForUseCase(useCase, paramName);
+
+        //then
+        Assertions.assertEquals(actual.getName(), expectedName);
+        Assertions.assertEquals(actual.getUseCase(), useCase);
+        Assertions.assertEquals(actual.isCollectionTyped(), expectedCollectionType);
+        Assertions.assertEquals(actual.isNullable(), expectedNullable);
+    }
+
+
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/YamlActionConfigParserTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/impl/YamlActionConfigParserTest.java
@@ -113,11 +113,11 @@ class YamlActionConfigParserTest {
         final YamlActionConfigParser underTest = spy(new YamlActionConfigParser(jsonRuleRegistry, mock(Validator.class)));
 
         //when
-        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.parse((InputStream) null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.parse((InputStream) null, false));
 
         //then
         final InOrder inOrder = inOrder(underTest, jsonRuleRegistry);
-        inOrder.verify(underTest).parse((InputStream) isNull());
+        inOrder.verify(underTest).parse((InputStream) isNull(), anyBoolean());
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -131,16 +131,16 @@ class YamlActionConfigParserTest {
 
         final YamlActionConfigParser underTest = spy(new YamlActionConfigParser(jsonRuleRegistry, mock(Validator.class)));
         doReturn(expected).when(underTest).convertActions(eq(rawJsonActions));
-        doReturn(rawJsonActions).when(underTest).parseAsRawJsonActions(eq(stream));
+        doReturn(rawJsonActions).when(underTest).parseAsRawJsonActions(eq(stream), anyBoolean());
 
         //when
-        final JsonActions actual = underTest.parse(stream);
+        final JsonActions actual = underTest.parse(stream, false);
 
         //then
         Assertions.assertEquals(expected, actual);
         final InOrder inOrder = inOrder(underTest, jsonRuleRegistry);
-        inOrder.verify(underTest).parse(eq(stream));
-        inOrder.verify(underTest).parseAsRawJsonActions(eq(stream));
+        inOrder.verify(underTest).parse(eq(stream), anyBoolean());
+        inOrder.verify(underTest).parseAsRawJsonActions(eq(stream), anyBoolean());
         inOrder.verify(underTest).convertActions(eq(rawJsonActions));
         inOrder.verifyNoMoreInteractions();
     }

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/RawConfigParamDefaultImplTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/RawConfigParamDefaultImplTest.java
@@ -1,5 +1,6 @@
 package com.github.nagyesta.yippeekijson.core.config.parser.raw;
 
+import com.github.nagyesta.yippeekijson.core.config.parser.impl.ParameterContext;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ class RawConfigParamDefaultImplTest {
         }
 
         @Override
-        public @NotNull Object suitableFor(final boolean stringMap, final boolean paramMap, final boolean repeat) {
+        public @NotNull Object suitableFor(final ParameterContext parameterContext) {
             return "null";
         }
     };
@@ -58,5 +59,21 @@ class RawConfigParamDefaultImplTest {
 
         //when + then exception
         Assertions.assertThrows(UnsupportedOperationException.class, underTest::asMaps);
+    }
+
+    @Test
+    void testAsStringMapShouldThrowException() {
+        //given
+
+        //when + then exception
+        Assertions.assertThrows(UnsupportedOperationException.class, underTest::asStringMap);
+    }
+
+    @Test
+    void testAsStringMapsShouldThrowException() {
+        //given
+
+        //when + then exception
+        Assertions.assertThrows(UnsupportedOperationException.class, underTest::asStringMaps);
     }
 }

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/RawJsonActionTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/RawJsonActionTest.java
@@ -1,6 +1,7 @@
 package com.github.nagyesta.yippeekijson.core.config.parser.raw;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -51,5 +52,32 @@ class RawJsonActionTest {
 
         //then
         Assertions.assertTrue(actual);
+    }
+
+    @SuppressWarnings({"EqualsWithItself", "ConstantConditions"})
+    @Test
+    void testEqualsShouldBeDefaultTrueIfSame() {
+        //given
+        final RawJsonAction first = new RawJsonAction();
+        first.setName(ACTION);
+
+        //when
+        final boolean actual = first.equals(first);
+
+        //then
+        Assertions.assertTrue(actual);
+    }
+
+    @Test
+    void testEqualsShouldBeDefaultFalseIfDifferentClass() {
+        //given
+        final RawJsonAction first = new RawJsonAction();
+        first.setName(ACTION);
+
+        //when
+        final boolean actual = first.equals(new Object());
+
+        //then
+        Assertions.assertFalse(actual);
     }
 }

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/RawJsonRuleTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/RawJsonRuleTest.java
@@ -1,11 +1,14 @@
 package com.github.nagyesta.yippeekijson.core.config.parser.raw;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.stream.Stream;
 
 class RawJsonRuleTest {
 
@@ -28,6 +31,17 @@ class RawJsonRuleTest {
         };
     }
 
+    private static Stream<Arguments> negativeConfigParamMapSource() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(null, Collections.emptyMap()))
+                .add(Arguments.of(null, Map.of(NAME, Map.of(NAME, NAME))))
+                .add(Arguments.of(StringUtils.EMPTY, Collections.emptyMap()))
+                .add(Arguments.of(StringUtils.EMPTY, Map.of(NAME, Map.of(NAME, NAME))))
+                .add(Arguments.of(StringUtils.SPACE, Collections.emptyMap()))
+                .add(Arguments.of(StringUtils.SPACE, Map.of(NAME, Map.of(NAME, NAME))))
+                .build();
+    }
+
     @ParameterizedTest
     @MethodSource("nullProvider")
     void testSettersShouldThrowExceptionsWhenCalledWithNulls(
@@ -42,5 +56,20 @@ class RawJsonRuleTest {
             underTest.setPath(path);
             underTest.setParams(params);
         });
+    }
+
+    @ParameterizedTest
+    @MethodSource("negativeConfigParamMapSource")
+    void testConfigParamMapShouldReturnEmptyMapIfKeyMissing(final String key, final Map<String, Map<String, Object>> map) {
+        //given
+        final RawJsonRule underTest = RawJsonRule.builder()
+                .putParams(map)
+                .build();
+
+        //when
+        final Map<String, RawConfigParam> actual = underTest.configParamMap(key);
+
+        //then
+        Assertions.assertEquals(Collections.<String, RawConfigParam>emptyMap(), actual);
     }
 }

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/params/RawParamConverterTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/config/parser/raw/params/RawParamConverterTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -20,6 +21,7 @@ class RawParamConverterTest {
     private static final String VALUE = "value";
     private static final Map<String, Object> VALUE_MAP = Map.of(KEY, VALUE);
     private static final int INT_42 = 42;
+    private static final BigInteger BIG_INT_42 = new BigInteger("42");
 
     private static Stream<Arguments> validInputProvider() {
         return Stream.<Arguments>builder()
@@ -35,7 +37,7 @@ class RawParamConverterTest {
                 .add(Arguments.of(null, IllegalArgumentException.class))
                 .add(Arguments.of(Collections.emptyMap(), IllegalArgumentException.class))
                 .add(Arguments.of(Collections.emptyList(), IllegalArgumentException.class))
-                .add(Arguments.of(INT_42, IllegalArgumentException.class))
+                .add(Arguments.of(BIG_INT_42, IllegalArgumentException.class))
                 .add(Arguments.of(Set.of(VALUE_MAP), IllegalArgumentException.class))
                 .add(Arguments.of(List.of(VALUE_MAP, VALUE), IllegalArgumentException.class))
                 .add(Arguments.of(List.of(INT_42), IllegalArgumentException.class))

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/function/HttpResourceContentFunctionTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/function/HttpResourceContentFunctionTest.java
@@ -1,0 +1,137 @@
+package com.github.nagyesta.yippeekijson.core.function;
+
+import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.params.RawConfigValue;
+import com.github.nagyesta.yippeekijson.core.http.HttpClient;
+import com.github.nagyesta.yippeekijson.core.http.HttpRequestContext;
+import com.google.common.base.Functions;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HttpResourceContentFunctionTest {
+
+    private static final String JSON = "{}";
+    private static final String NAME = "name";
+    private static final String URI = "uri";
+    private static final String METHOD = "method";
+    private static final String HEADER = "header";
+
+    private static Stream<Arguments> nullProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(null, null))
+                .add(Arguments.of(mock(FunctionRegistry.class), null))
+                .add(Arguments.of(null, mock(HttpClient.class)))
+                .build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullProvider")
+    void testConstructorShouldThrowExceptionIfNullsProvidedForMandatoryParams(final FunctionRegistry functionRegistry,
+                                                                              final HttpClient httpClient) {
+        //given
+
+        //when + then exception
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new HttpResourceContentFunction(
+                null,
+                null, null, null, null,
+                functionRegistry, httpClient));
+    }
+
+    @Test
+    void testBuildOverrideContextShouldUseTheFunctionsToTransformInputNoDefaults() {
+        //given
+        FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        final Map<String, RawConfigParam> uriMap = this.prepareFunctionMockCall(functionRegistry);
+
+        HttpResourceContentFunction underTest = new HttpResourceContentFunction(
+                uriMap,
+                null, null, Map.of(NAME, HEADER), null,
+                functionRegistry, httpClient);
+
+        //when
+        final HttpRequestContext actual = underTest.buildOverrideContext(URI);
+
+        //then
+        assertValid(actual);
+    }
+
+    @Test
+    void testBuildOverrideContextShouldUseTheFunctionsToTransformInput() {
+        //given
+        FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        final Map<String, RawConfigParam> uriMap = this.prepareFunctionMockCall(functionRegistry);
+
+        HttpResourceContentFunction underTest = new HttpResourceContentFunction(
+                uriMap,
+                NAME, HttpRequestContext.HttpMethod.GET.name(), Map.of(NAME, HEADER), StandardCharsets.UTF_8.name(),
+                functionRegistry, httpClient);
+
+        //when
+        final HttpRequestContext actual = underTest.buildOverrideContext(URI);
+
+        //then
+        assertValid(actual);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    void testApplyShouldFallbackWhenTransformFunctionsMissing() {
+        //given
+        FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        HttpClient httpClient = mock(HttpClient.class);
+
+        HttpResourceContentFunction underTest = new HttpResourceContentFunction(
+                null,
+                URI, HttpRequestContext.HttpMethod.POST.name(), Map.of(NAME, HEADER), StandardCharsets.UTF_8.name(),
+                functionRegistry, httpClient);
+
+        final HttpRequestContext baseContext = HttpRequestContext.builder()
+                .uri(URI)
+                .httpMethod(HttpRequestContext.HttpMethod.POST)
+                .addHeader(NAME, HEADER)
+                .charset(StandardCharsets.UTF_8)
+                .build();
+        final HttpRequestContext emptyOverrides = HttpRequestContext.builder()
+                .httpMethod((HttpRequestContext.HttpMethod) null)
+                .uri(null)
+                .charset(null)
+                .build();
+        when(httpClient.fetch(eq(baseContext), eq(emptyOverrides))).thenReturn(JSON);
+
+        //when
+        final String actual = underTest.apply(null);
+
+        //then
+        Assertions.assertEquals(JSON, actual);
+    }
+
+    @NotNull
+    private Map<String, RawConfigParam> prepareFunctionMockCall(final FunctionRegistry functionRegistry) {
+        final Map<String, RawConfigParam> paramMap = Map.of(NAME, new RawConfigValue(NAME, HttpResourceContentFunctionTest.URI));
+        when(functionRegistry.<String, String>lookupFunction(eq(paramMap))).thenReturn(Functions.identity());
+        return paramMap;
+    }
+
+    private void assertValid(final HttpRequestContext actual) {
+        Assertions.assertEquals(URI, actual.getUri());
+        Assertions.assertNull(actual.getHttpMethod());
+        Assertions.assertEquals(Map.<String, List<String>>of(), actual.getHeaders());
+        Assertions.assertNull(actual.getCharset());
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/function/HttpResourceContentMapFunctionTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/function/HttpResourceContentMapFunctionTest.java
@@ -1,0 +1,152 @@
+package com.github.nagyesta.yippeekijson.core.function;
+
+import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.params.RawConfigValue;
+import com.github.nagyesta.yippeekijson.core.http.HttpClient;
+import com.github.nagyesta.yippeekijson.core.http.HttpRequestContext;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static com.google.common.net.HttpHeaders.ACCEPT_CHARSET;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HttpResourceContentMapFunctionTest {
+
+    private static final String JSON = "{}";
+    private static final String NAME = "name";
+    private static final String URI = "uri";
+    private static final String METHOD = "method";
+    private static final String HEADER = "header";
+
+    private static Stream<Arguments> nullProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(null, null))
+                .add(Arguments.of(mock(FunctionRegistry.class), null))
+                .add(Arguments.of(null, mock(HttpClient.class)))
+                .build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullProvider")
+    void testConstructorShouldThrowExceptionIfNullsProvidedForMandatoryParams(final FunctionRegistry functionRegistry,
+                                                                              final HttpClient httpClient) {
+        //given
+
+        //when + then exception
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new HttpResourceContentMapFunction(
+                null, null, null,
+                null, null, null, null,
+                functionRegistry, httpClient));
+    }
+
+    @Test
+    void testBuildOverrideContextShouldUseTheFunctionsToTransformInputNoDefaults() {
+        //given
+        FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        final Map<String, RawConfigParam> uriMap = this.<String>prepareFunctionMockCall(functionRegistry, URI);
+        final Map<String, RawConfigParam> methodMap = this.<String>prepareFunctionMockCall(functionRegistry, METHOD);
+        final Map<String, RawConfigParam> headerMap = this.<Map<String, String>>prepareFunctionMockCall(functionRegistry, HEADER);
+
+        HttpResourceContentMapFunction underTest = new HttpResourceContentMapFunction(
+                uriMap, methodMap, headerMap,
+                null, null, null, null,
+                functionRegistry, httpClient);
+
+        final Map<String, Object> mapOverride = Map.of(
+                URI, URI,
+                METHOD, HttpRequestContext.HttpMethod.POST.name(),
+                HEADER, Map.of(NAME, HEADER));
+
+        //when
+        final HttpRequestContext actual = underTest.buildOverrideContext(mapOverride);
+
+        //then
+        assertValid(actual);
+    }
+
+    @Test
+    void testBuildOverrideContextShouldUseTheFunctionsToTransformInput() {
+        //given
+        FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        final Map<String, RawConfigParam> uriMap = this.<String>prepareFunctionMockCall(functionRegistry, URI);
+        final Map<String, RawConfigParam> methodMap = this.<String>prepareFunctionMockCall(functionRegistry, METHOD);
+        final Map<String, RawConfigParam> headerMap = this.<Map<String, String>>prepareFunctionMockCall(functionRegistry, HEADER);
+
+        HttpResourceContentMapFunction underTest = new HttpResourceContentMapFunction(
+                uriMap, methodMap, headerMap,
+                NAME, HttpRequestContext.HttpMethod.GET.name(), null, StandardCharsets.UTF_8.name(),
+                functionRegistry, httpClient);
+
+        final Map<String, Object> mapOverride = Map.of(
+                URI, URI,
+                METHOD, HttpRequestContext.HttpMethod.POST.name(),
+                HEADER, Map.of(NAME, HEADER));
+
+        //when
+        final HttpRequestContext actual = underTest.buildOverrideContext(mapOverride);
+
+        //then
+        assertValid(actual);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    void testApplyShouldFallbackWhenTransformFunctionsMissing() {
+        //given
+        FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        HttpClient httpClient = mock(HttpClient.class);
+
+        HttpResourceContentMapFunction underTest = new HttpResourceContentMapFunction(
+                null, null, null,
+                URI, HttpRequestContext.HttpMethod.POST.name(), Map.of(NAME, HEADER), StandardCharsets.UTF_8.name(),
+                functionRegistry, httpClient);
+
+        final Map<String, Object> mapOverride = Map.of();
+        final HttpRequestContext baseContext = HttpRequestContext.builder()
+                .uri(URI)
+                .httpMethod(HttpRequestContext.HttpMethod.POST)
+                .addHeader(NAME, HEADER)
+                .charset(StandardCharsets.UTF_8)
+                .build();
+        final HttpRequestContext emptyOverrides = HttpRequestContext.builder()
+                .httpMethod((HttpRequestContext.HttpMethod) null)
+                .build();
+        when(httpClient.fetch(eq(baseContext), eq(emptyOverrides))).thenReturn(JSON);
+
+        //when
+        final String actual = underTest.apply(mapOverride);
+
+        //then
+        Assertions.assertEquals(JSON, actual);
+    }
+
+    @SuppressWarnings("unchecked")
+    @NotNull
+    private <T> Map<String, RawConfigParam> prepareFunctionMockCall(final FunctionRegistry functionRegistry, final String value) {
+        final Map<String, RawConfigParam> paramMap = Map.of(NAME, new RawConfigValue(NAME, value));
+        when(functionRegistry.<Map<String, Object>, T>lookupFunction(eq(paramMap)))
+                .thenReturn(map -> (T) map.get(value));
+        return paramMap;
+    }
+
+    private void assertValid(final HttpRequestContext actual) {
+        Assertions.assertEquals(URI, actual.getUri());
+        Assertions.assertEquals(HttpRequestContext.HttpMethod.POST, actual.getHttpMethod());
+        Assertions.assertEquals(Map.of(ACCEPT_CHARSET, List.of(StandardCharsets.UTF_8.name()), NAME, List.of(HEADER)), actual.getHeaders());
+        Assertions.assertEquals(StandardCharsets.UTF_8, actual.getCharset());
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/function/JsonParseFunctionTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/function/JsonParseFunctionTest.java
@@ -1,0 +1,85 @@
+package com.github.nagyesta.yippeekijson.core.function;
+
+import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
+import com.github.nagyesta.yippeekijson.core.config.parser.impl.JsonMapperImpl;
+import com.github.nagyesta.yippeekijson.core.exception.AbortTransformationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigInteger;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.mock;
+
+class JsonParseFunctionTest {
+
+    private static final String EMPTY = "{}";
+    private static final String KEY_42 = "{\"key\": 42}";
+    private static final String KEY = "key";
+    private static final BigInteger INT_42 = new BigInteger("42");
+    private static final String INVALID = "{";
+
+    private static Stream<Arguments> invalidInputProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(null, AbortTransformationException.class))
+                .add(Arguments.of(INVALID, AbortTransformationException.class))
+                .build();
+    }
+
+    private static Stream<Arguments> validInputProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(EMPTY, Map.of()))
+                .add(Arguments.of(KEY_42, Map.of(KEY, INT_42)))
+                .build();
+    }
+
+    @Test
+    void testConstructorShouldThrowExceptionForNull() {
+        //given
+
+        //when + then exception
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new JsonParseFunction(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidInputProvider")
+    void testApplyShouldThrowExceptionForInvalidData(final String input, final Class<Exception> expected) {
+        //given
+        JsonMapper jsonMapper = new JsonMapperImpl();
+        final JsonParseFunction underTest = new JsonParseFunction(jsonMapper);
+
+        //when + then exception
+        Assertions.assertThrows(expected, () -> underTest.apply(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validInputProvider")
+    void testApplyShouldParseValidData(final String input, final Map<?, ?> expected) {
+        //given
+        JsonMapper jsonMapper = new JsonMapperImpl();
+        final JsonParseFunction underTest = new JsonParseFunction(jsonMapper);
+
+        //when
+        final Object actual = underTest.apply(input);
+
+        //then
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    void testToStringShouldContainClassName() {
+        //given
+        JsonMapper jsonMapper = mock(JsonMapper.class);
+        final JsonParseFunction underTest = new JsonParseFunction(jsonMapper);
+
+        //when
+        final String actual = underTest.toString();
+
+        //then
+        Assertions.assertTrue(actual.contains(JsonParseFunction.class.getSimpleName()));
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/function/helper/HttpResourceContentSupportTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/function/helper/HttpResourceContentSupportTest.java
@@ -1,0 +1,92 @@
+package com.github.nagyesta.yippeekijson.core.function.helper;
+
+import com.github.nagyesta.yippeekijson.core.http.HttpClient;
+import com.github.nagyesta.yippeekijson.core.http.HttpRequestContext;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static com.github.nagyesta.yippeekijson.core.http.HttpRequestContext.HttpMethod.GET;
+import static com.google.common.net.HttpHeaders.USER_AGENT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HttpResourceContentSupportTest {
+
+    private static final String DEFAULT_URI = "http://localhost/default";
+    private static final String OVERRIDE_URI = "http://localhost/override";
+    private static final String SUCCESS = "{\"success\": true}";
+
+    @Test
+    void testApplyShouldExecuteStepsInOrderWhenCalledWithValidData() {
+        //given
+        final Map<String, String> headers = Map.of(USER_AGENT, USER_AGENT);
+        final String charset = StandardCharsets.UTF_8.name();
+
+        final HttpRequestContext overrideContext = HttpRequestContext.builder()
+                .uri(OVERRIDE_URI)
+                .build();
+
+        HttpClient httpClient = mock(HttpClient.class);
+        when(httpClient.fetch(any(HttpRequestContext.class), same(overrideContext))).thenReturn(SUCCESS);
+        HttpResourceContentSupport<Object> underTest = new HttpResourceContentSupport<>(
+                httpClient, DEFAULT_URI, GET.name(), headers, charset) {
+
+            @Override
+            protected @NotNull HttpRequestContext buildOverrideContext(final Object override) {
+                Assertions.assertEquals(OVERRIDE_URI, override);
+                return overrideContext;
+            }
+        };
+
+        //when
+        final String actual = underTest.apply(OVERRIDE_URI);
+
+        //then
+        Assertions.assertEquals(SUCCESS, actual);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    void testConstructorShouldThrowExceptionWhenHttpClientMissing() {
+        //given
+
+        //when + then exception
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            new HttpResourceContentSupport<>(
+                    null, null, null, null, null) {
+
+                @Override
+                protected @NotNull HttpRequestContext buildOverrideContext(final Object override) {
+                    return HttpRequestContext.builder().build();
+                }
+            };
+        });
+    }
+
+    @Test
+    void testToStringShouldContainUriAndMethod() {
+        //given
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResourceContentSupport<Object> underTest = new HttpResourceContentSupport<>(
+                httpClient, DEFAULT_URI, null, null, null) {
+
+            @Override
+            protected @NotNull HttpRequestContext buildOverrideContext(final Object override) {
+                return HttpRequestContext.builder().build();
+            }
+        };
+
+        //when
+        final String actual = underTest.toString();
+
+        //then
+        Assertions.assertTrue(actual.contains(DEFAULT_URI));
+        Assertions.assertTrue(actual.contains(GET.name()));
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/http/HttpRequestContextTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/http/HttpRequestContextTest.java
@@ -1,0 +1,62 @@
+package com.github.nagyesta.yippeekijson.core.http;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+class HttpRequestContextTest {
+
+    private static final HttpRequestContext EMPTY = HttpRequestContext.builder().build();
+    private static final String URI = "URI";
+
+    private static HttpRequestContext buildPost() {
+        return HttpRequestContext.builder()
+                .uri(URI)
+                .httpMethod(HttpRequestContext.HttpMethod.POST)
+                .build();
+    }
+
+    private static Stream<Arguments> pairSupplier() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(EMPTY, null, false))
+                .add(Arguments.of(EMPTY, EMPTY, true))
+                .add(Arguments.of(EMPTY, new Object(), false))
+                .add(Arguments.of(buildPost(), buildPost(), true))
+                .add(Arguments.of(buildPost(), EMPTY, false))
+                .build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("pairSupplier")
+    void testEquals(final Object underTest, final Object other, final boolean expected) {
+        //given
+
+        //when
+        final boolean actual = underTest.equals(other);
+
+        //then
+        Assertions.assertEquals(expected, actual);
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("pairSupplier")
+    void testHashCode(final Object underTest, final Object other, final boolean expected) {
+        //given
+
+        //when
+        final int actualHash = Objects.hash(underTest);
+        final int otherHash = Objects.hash(other);
+
+        //then
+        if (expected) {
+            Assertions.assertEquals(otherHash, actualHash);
+        } else {
+            Assertions.assertNotEquals(otherHash, actualHash);
+        }
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/http/impl/DefaultHttpClientTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/http/impl/DefaultHttpClientTest.java
@@ -1,0 +1,185 @@
+package com.github.nagyesta.yippeekijson.core.http.impl;
+
+import com.github.nagyesta.yippeekijson.core.config.entities.HttpConfig;
+import com.github.nagyesta.yippeekijson.core.exception.AbortTransformationException;
+import com.github.nagyesta.yippeekijson.core.http.HttpClient;
+import com.github.nagyesta.yippeekijson.core.http.HttpRequestContext;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static com.google.common.net.HttpHeaders.*;
+import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
+
+@Slf4j
+class DefaultHttpClientTest {
+
+    private static final String SUCCESS = "success";
+    private static final Map<String, Boolean> JSON_MAP = Map.of(SUCCESS, Boolean.TRUE);
+    private static final String SUCCESS_TRUE = Json.write(JSON_MAP);
+    private static final String USER_AGENT_VALUE = "user agent";
+    private static final int SUCCESS_STATUS_MIN = 200;
+    private static final int SUCCESS_STATUS_MAX = 299;
+    private static final int TIMEOUT_SECONDS = 5;
+    private static final int TIMEOUT_OFF = 0;
+    private static final String SUCCESS_JSON = "/success.json";
+    private static final String FAILURE_JSON = "/failure.json";
+    private static final String GET = "GET";
+    private static final String POST = "POST";
+
+    private static WireMockServer wireMockServer;
+
+    @BeforeAll
+    static void beforeAll() {
+        wireMockServer = new WireMockServer(options().dynamicPort());
+        wireMockServer.start();
+
+        final StubMapping getMapping = WireMock.get(SUCCESS_JSON)
+                .withHeader(USER_AGENT, new EqualToPattern(USER_AGENT_VALUE))
+                .withHeader(ACCEPT, new EqualToPattern(APPLICATION_JSON_VALUE))
+                .withHeader(ACCEPT_CHARSET, new EqualToPattern(StandardCharsets.UTF_8.name()))
+                .willReturn(ResponseDefinitionBuilder.okForJson(JSON_MAP))
+                .build();
+        wireMockServer.addStubMapping(getMapping);
+
+        final StubMapping postMapping = WireMock.post(SUCCESS_JSON)
+                .withHeader(USER_AGENT, new EqualToPattern(USER_AGENT_VALUE))
+                .withHeader(ACCEPT, new EqualToPattern(APPLICATION_JSON_VALUE))
+                .withHeader(ACCEPT_CHARSET, new EqualToPattern(StandardCharsets.UTF_8.name()))
+                .willReturn(ResponseDefinitionBuilder.okForJson(JSON_MAP))
+                .build();
+        wireMockServer.addStubMapping(postMapping);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (wireMockServer != null && wireMockServer.isRunning()) {
+            wireMockServer.stop();
+        }
+    }
+
+    private static Stream<Arguments> nullSource() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(null, null))
+                .add(Arguments.of(HttpRequestContext.builder().build(), null))
+                .add(Arguments.of(null, HttpRequestContext.builder().build()))
+                .build();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {GET, POST})
+    void testFetchShouldSendRequestAndProcessSuccessResponse(final String method) {
+        //given
+        String baseUrl = wireMockServer.baseUrl();
+
+        final HttpRequestContext requestContext = HttpRequestContext.builder()
+                .httpMethod(method)
+                .uri(baseUrl + SUCCESS_JSON)
+                .build();
+
+        HttpConfig config = httpConfig(true, TIMEOUT_OFF);
+        HttpClient underTest = new DefaultHttpClient(config);
+
+        //when
+        final String actual = underTest.fetch(requestContext);
+
+        //then
+        Assertions.assertEquals(SUCCESS_TRUE, actual);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {GET, POST})
+    void testFetchShouldSendRequestAndThrowExceptionForWrongStatusCode(final String method) {
+        //given
+        String baseUrl = wireMockServer.baseUrl();
+
+        final HttpRequestContext requestContext = HttpRequestContext.builder()
+                .httpMethod(method)
+                .uri(baseUrl + FAILURE_JSON)
+                .build();
+
+        HttpConfig config = httpConfig(false, TIMEOUT_SECONDS);
+        HttpClient underTest = new DefaultHttpClient(config);
+
+        //when + then exception
+        Assertions.assertThrows(AbortTransformationException.class, () -> underTest.fetch(requestContext));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {GET, POST})
+    void testFetchMergeShouldSendRequestAndProcessSuccessResponse(final String method) {
+        //given
+        String baseUrl = wireMockServer.baseUrl();
+
+        final HttpRequestContext requestContext = HttpRequestContext.builder()
+                .httpMethod(method)
+                .uri(baseUrl + FAILURE_JSON)
+                .addHeaders(Map.of(USER_AGENT, USER_AGENT))
+                .addHeader(ACCEPT_CHARSET, StandardCharsets.UTF_8.name())
+                .build();
+
+        final HttpRequestContext overrideContext = HttpRequestContext.builder()
+                .uri(baseUrl + SUCCESS_JSON)
+                .addHeader(USER_AGENT, USER_AGENT_VALUE)
+                .addHeader(ACCEPT, APPLICATION_JSON_VALUE)
+                .build();
+
+        HttpConfig config = httpConfig(false, TIMEOUT_SECONDS);
+        HttpClient underTest = new DefaultHttpClient(config);
+
+        //when
+        final String actual = underTest.fetch(requestContext, overrideContext);
+
+        //then
+        Assertions.assertEquals(SUCCESS_TRUE, actual);
+    }
+
+    @Test
+    void testFetchShouldThrowExceptionForNull() {
+        //given
+
+        HttpConfig config = httpConfig(false, TIMEOUT_SECONDS);
+        HttpClient underTest = new DefaultHttpClient(config);
+
+        //when + then exception
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.fetch(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullSource")
+    void testFetchShouldThrowExceptionForNulls(final HttpRequestContext base, final HttpRequestContext override) {
+        //given
+        HttpConfig config = httpConfig(false, TIMEOUT_SECONDS);
+        HttpClient underTest = new DefaultHttpClient(config);
+
+        //when + then exception
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.fetch(base, override));
+    }
+
+    private HttpConfig httpConfig(final boolean addDefaultHeaders, final int timeout) {
+        return HttpConfig.builder()
+                .addDefaultHeaders(addDefaultHeaders)
+                .maxSuccessStatus(SUCCESS_STATUS_MAX)
+                .minSuccessStatus(SUCCESS_STATUS_MIN)
+                .timeoutSeconds(timeout)
+                .userAgent(USER_AGENT_VALUE)
+                .build();
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/predicate/helper/CombiningPredicateSupportTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/predicate/helper/CombiningPredicateSupportTest.java
@@ -1,4 +1,4 @@
-package com.github.nagyesta.yippeekijson.core.predicate;
+package com.github.nagyesta.yippeekijson.core.predicate.helper;
 
 import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
 import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
@@ -13,7 +13,7 @@ import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
 
-class CombiningPredicateTest {
+class CombiningPredicateSupportTest {
 
     private static Stream<Arguments> nullProvider() {
         return Stream.<Arguments>builder()
@@ -30,7 +30,7 @@ class CombiningPredicateTest {
         //given
 
         //when + then exception
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new CombiningPredicate(config, functionRegistry) {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new CombiningPredicateSupport(config, functionRegistry) {
             @Override
             public boolean test(final Object o) {
                 return false;

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonCalculateRuleTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonCalculateRuleTest.java
@@ -19,6 +19,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.yippeekijson.core.rule.impl.JsonCalculateRule.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -47,6 +48,7 @@ class JsonCalculateRuleTest {
         );
     }
 
+    @SuppressWarnings("unchecked")
     @ParameterizedTest
     @MethodSource("validInputProvider")
     void testAcceptShouldReplaceMatchingStringsOnly(final String input, final String path, final Predicate<Object> matches,
@@ -69,7 +71,7 @@ class JsonCalculateRuleTest {
 
         final FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
         when(functionRegistry.lookupFunction(anyMap())).thenReturn(bd -> calculate.apply((BigDecimal) bd));
-        when(functionRegistry.lookupPredicate(anyMap())).thenReturn(matches);
+        when(functionRegistry.lookupPredicate(anyMap(), any(Predicate.class))).thenReturn(matches);
 
         final JsonCalculateRule rule = new JsonCalculateRule(functionRegistry, raw);
 

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonDeleteFromMapRuleTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonDeleteFromMapRuleTest.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.github.nagyesta.yippeekijson.core.rule.impl.JsonDeleteFromMapRule.*;
-import static com.github.nagyesta.yippeekijson.core.rule.impl.JsonMapRule.PARAM_PREDICATE;
 import static com.github.nagyesta.yippeekijson.core.rule.impl.JsonReplaceMapRule.RULE_NAME;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
@@ -48,9 +47,8 @@ class JsonDeleteFromMapRuleTest {
                 s -> String.valueOf(s).startsWith("remove"),
                 s -> String.valueOf(s).startsWith("keep"),
                 s -> String.valueOf(s).startsWith("remove"));
-        when(functionRegistry.jsonMapper()).thenReturn(jsonMapper);
 
-        JsonDeleteFromMapRule underTest = new JsonDeleteFromMapRule(functionRegistry, raw);
+        JsonDeleteFromMapRule underTest = new JsonDeleteFromMapRule(functionRegistry, jsonMapper, raw);
 
         //when
         underTest.accept(document);

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonDeleteRuleTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonDeleteRuleTest.java
@@ -1,6 +1,5 @@
 package com.github.nagyesta.yippeekijson.core.rule.impl;
 
-import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
 import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
 import com.github.nagyesta.yippeekijson.core.config.parser.impl.JsonMapperImpl;
 import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawJsonRule;
@@ -14,7 +13,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.yippeekijson.core.rule.impl.JsonDeleteRule.RULE_NAME;
-import static org.mockito.Mockito.mock;
 
 class JsonDeleteRuleTest {
 
@@ -47,9 +45,7 @@ class JsonDeleteRuleTest {
                 .order(0)
                 .build();
 
-        final FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
-
-        final JsonDeleteRule rule = new JsonDeleteRule(functionRegistry, raw);
+        final JsonDeleteRule rule = new JsonDeleteRule(raw);
 
         //when
         rule.accept(document);

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonReplaceMapRuleTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonReplaceMapRuleTest.java
@@ -18,9 +18,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import static com.github.nagyesta.yippeekijson.core.rule.impl.JsonMapRule.PARAM_PREDICATE;
-import static com.github.nagyesta.yippeekijson.core.rule.impl.JsonReplaceMapRule.PARAM_MAP_FUNCTION;
-import static com.github.nagyesta.yippeekijson.core.rule.impl.JsonReplaceMapRule.RULE_NAME;
+import static com.github.nagyesta.yippeekijson.core.rule.impl.JsonReplaceMapRule.*;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -77,9 +75,8 @@ class JsonReplaceMapRuleTest {
         final FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
         when(functionRegistry.lookupFunction(anyMap())).thenReturn(o -> transform.apply((Map<String, Object>) o));
         when(functionRegistry.lookupPredicate(anyMap())).thenReturn(matches);
-        when(functionRegistry.jsonMapper()).thenReturn(jsonMapper);
 
-        final JsonReplaceMapRule rule = new JsonReplaceMapRule(functionRegistry, raw);
+        final JsonReplaceMapRule rule = new JsonReplaceMapRule(functionRegistry, jsonMapper, raw);
 
         //when
         rule.accept(document);
@@ -107,9 +104,8 @@ class JsonReplaceMapRuleTest {
 
         final FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
         when(functionRegistry.lookupFunction(anyMap())).thenReturn(o -> transform.apply((Map<String, Object>) o));
-        when(functionRegistry.jsonMapper()).thenReturn(jsonMapper);
 
-        final JsonReplaceMapRule rule = new JsonReplaceMapRule(functionRegistry, raw);
+        final JsonReplaceMapRule rule = new JsonReplaceMapRule(functionRegistry, jsonMapper, raw);
 
         //when + then exception
         Assertions.assertThrows(expected, () -> rule.accept(document));
@@ -130,9 +126,8 @@ class JsonReplaceMapRuleTest {
 
         final FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
         when(functionRegistry.lookupFunction(anyMap())).thenReturn(o -> COPY_WITH_SUFFIX.apply((Map<String, Object>) o));
-        when(functionRegistry.jsonMapper()).thenReturn(jsonMapper);
 
-        final JsonReplaceMapRule rule = new JsonReplaceMapRule(functionRegistry, raw);
+        final JsonReplaceMapRule rule = new JsonReplaceMapRule(functionRegistry, jsonMapper, raw);
 
         //when
         final String actual = rule.toString();

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonReplaceRuleTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonReplaceRuleTest.java
@@ -18,6 +18,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.yippeekijson.core.rule.impl.JsonReplaceRule.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,6 +45,7 @@ class JsonReplaceRuleTest {
         );
     }
 
+    @SuppressWarnings("unchecked")
     @ParameterizedTest
     @MethodSource("validInputProvider")
     void testAcceptShouldReplaceMatchingStringsOnly(final String input, final String path, final Predicate<Object> matches,
@@ -60,7 +62,7 @@ class JsonReplaceRuleTest {
 
         final FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
         when(functionRegistry.lookupFunction(anyMap())).thenReturn(s -> replace.apply((String) s));
-        when(functionRegistry.lookupPredicate(anyMap())).thenReturn(matches);
+        when(functionRegistry.lookupPredicate(anyMap(), any(Predicate.class))).thenReturn(matches);
 
         final JsonReplaceRule rule = new JsonReplaceRule(functionRegistry, raw);
 

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonValidationRuleTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/rule/impl/JsonValidationRuleTest.java
@@ -1,0 +1,151 @@
+package com.github.nagyesta.yippeekijson.core.rule.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
+import com.github.nagyesta.yippeekijson.core.config.parser.impl.JsonMapperImpl;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawJsonRule;
+import com.github.nagyesta.yippeekijson.core.exception.AbortTransformationException;
+import com.github.nagyesta.yippeekijson.core.exception.StopRuleProcessingException;
+import com.github.nagyesta.yippeekijson.core.rule.strategy.TransformationControlStrategy;
+import com.github.nagyesta.yippeekijson.core.rule.strategy.ViolationStrategy;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.mapper.MappingException;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static com.github.nagyesta.yippeekijson.core.rule.impl.JsonValidationRule.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class JsonValidationRuleTest {
+
+    private static final String ROOT_NOT_EXISTING_CHILD = "$.something";
+    private static final String TEST_SCHEMA_JSON = "/validation/test-schema.json";
+    private static final String INPUT_JSON = "/validation/validation-input.json";
+    private static final String OUTPUT_JSON = "/validation/validation-output.json";
+
+    private static Stream<Arguments> strategyProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(TransformationControlStrategy.SKIP_REST, StopRuleProcessingException.class))
+                .add(Arguments.of(TransformationControlStrategy.ABORT, AbortTransformationException.class))
+                .add(Arguments.of(TransformationControlStrategy.CONTINUE, null))
+                .build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("strategyProvider")
+    void testAcceptShouldHandleValidationIssuesAndIgnorePath(final TransformationControlStrategy strategy,
+                                                             final Class<Exception> expectedException) throws JsonProcessingException {
+        //given
+        final JsonMapperImpl jsonMapper = new JsonMapperImpl();
+        final ObjectMapper objectMapper = jsonMapper.objectMapper();
+        JsonSchemaFactory factory = JsonSchemaFactory
+                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
+                .objectMapper(objectMapper)
+                .build();
+        final JsonSchema jsonSchema = factory.getSchema(getResource(TEST_SCHEMA_JSON));
+
+        FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        RawJsonRule jsonRule = RawJsonRule.builder()
+                .name(RULE_NAME)
+                .putParams(Map.of(
+                        PARAM_SCHEMA, Map.of(),
+                        PARAM_ON_FAILURE, Map.of(
+                                PARAM_ON_FAILURE_TRANSFORMATION, strategy.name(),
+                                PARAM_ON_FAILURE_VIOLATION, ViolationStrategy.COMMENT_JSON.name())))
+                .order(0)
+                .path(ROOT_NOT_EXISTING_CHILD)
+                .build();
+        when(functionRegistry.lookupSupplier(anyMap())).thenReturn(() -> jsonSchema);
+
+        JsonValidationRule underTest = new JsonValidationRule(functionRegistry, jsonRule);
+        DocumentContext documentContext = JsonPath.parse(getResource(INPUT_JSON), jsonMapper.parserConfiguration());
+
+        //when
+        if (expectedException == null) {
+            Assertions.assertDoesNotThrow(() -> underTest.accept(documentContext));
+        } else {
+            Assertions.assertThrows(expectedException, () -> underTest.accept(documentContext));
+        }
+
+        //then
+        final String actualJson = documentContext.jsonString();
+        final String expectedJson = getResource(OUTPUT_JSON);
+
+        final JsonNode actual = objectMapper.readTree(actualJson);
+        final JsonNode expected = objectMapper.readTree(expectedJson);
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    private String getResource(final String resourcePath) {
+        try {
+            return IOUtils.resourceToString(resourcePath, StandardCharsets.UTF_8);
+        } catch (final IOException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    @Test
+    void testAcceptShouldHandleMappingExceptions() {
+        //given
+        FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        RawJsonRule jsonRule = RawJsonRule.builder()
+                .name(RULE_NAME)
+                .putParams(Map.of(
+                        PARAM_SCHEMA, Map.of(),
+                        PARAM_ON_FAILURE, Map.of(
+                                PARAM_ON_FAILURE_TRANSFORMATION, TransformationControlStrategy.CONTINUE.name(),
+                                PARAM_ON_FAILURE_VIOLATION, ViolationStrategy.COMMENT_JSON.name())))
+                .order(0)
+                .path(ROOT_NOT_EXISTING_CHILD)
+                .build();
+        when(functionRegistry.lookupSupplier(anyMap())).thenReturn(() -> null);
+
+        JsonValidationRule underTest = new JsonValidationRule(functionRegistry, jsonRule);
+        DocumentContext documentContext = mock(DocumentContext.class);
+        doThrow(MappingException.class).when(documentContext).read(anyString(), eq(JsonNode.class));
+
+        //when + then exception
+        Assertions.assertThrows(IllegalStateException.class, () -> underTest.accept(documentContext));
+    }
+
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {ROOT_NOT_EXISTING_CHILD})
+    void testConstructorShouldFailForInvalidEnumName(final String enumName) {
+        //given
+        FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        RawJsonRule jsonRule = RawJsonRule.builder()
+                .name(RULE_NAME)
+                .putParams(Map.of(
+                        PARAM_SCHEMA, Map.of(),
+                        PARAM_ON_FAILURE, Map.of(
+                                PARAM_ON_FAILURE_TRANSFORMATION, TransformationControlStrategy.CONTINUE.name(),
+                                PARAM_ON_FAILURE_VIOLATION, enumName)))
+                .order(0)
+                .path(ROOT_NOT_EXISTING_CHILD)
+                .build();
+        when(functionRegistry.lookupSupplier(anyMap())).thenReturn(() -> null);
+
+        //when + then exception
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new JsonValidationRule(functionRegistry, jsonRule));
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/rule/strategy/TransformationControlStrategyTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/rule/strategy/TransformationControlStrategyTest.java
@@ -1,0 +1,50 @@
+package com.github.nagyesta.yippeekijson.core.rule.strategy;
+
+import com.github.nagyesta.yippeekijson.core.exception.AbortTransformationException;
+import com.github.nagyesta.yippeekijson.core.exception.StopRuleProcessingException;
+import com.networknt.schema.ValidationMessage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.mock;
+
+class TransformationControlStrategyTest {
+
+    private static Stream<Arguments> inputSupplier() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(TransformationControlStrategy.ABORT, notEmptySet(), AbortTransformationException.class))
+                .add(Arguments.of(TransformationControlStrategy.CONTINUE, notEmptySet(), null))
+                .add(Arguments.of(TransformationControlStrategy.SKIP_REST, notEmptySet(), StopRuleProcessingException.class))
+                .add(Arguments.of(TransformationControlStrategy.ABORT, Set.of(), null))
+                .add(Arguments.of(TransformationControlStrategy.CONTINUE, Set.of(), null))
+                .add(Arguments.of(TransformationControlStrategy.SKIP_REST, Set.of(), null))
+                .add(Arguments.of(TransformationControlStrategy.ABORT, null, null))
+                .add(Arguments.of(TransformationControlStrategy.CONTINUE, null, null))
+                .add(Arguments.of(TransformationControlStrategy.SKIP_REST, null, null))
+                .build();
+    }
+
+    private static Set<ValidationMessage> notEmptySet() {
+        return Set.of(mock(ValidationMessage.class), mock(ValidationMessage.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputSupplier")
+    void testAcceptShouldThrowExceptionWhenViolationsFoundAndNotIgnored(final TransformationControlStrategy underTest,
+                                                                        final Set<ValidationMessage> violations,
+                                                                        final Class<Exception> expected) {
+        //given
+
+        //when + then
+        if (expected != null) {
+            Assertions.assertThrows(expected, () -> underTest.accept(violations));
+        } else {
+            Assertions.assertDoesNotThrow(() -> underTest.accept(violations));
+        }
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/rule/strategy/ViolationStrategyTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/rule/strategy/ViolationStrategyTest.java
@@ -1,0 +1,164 @@
+package com.github.nagyesta.yippeekijson.core.rule.strategy;
+
+import com.fasterxml.jackson.databind.*;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.*;
+
+class ViolationStrategyTest {
+
+    private static final String INPUT_JSON = "/validation/validation-input.json";
+    private static final String TEST_SCHEMA_JSON = "/validation/test-schema.json";
+    private static final String TEST_SCHEMA_INTEGER_JSON = "/validation/test-schema-integer.json";
+    private static final String OUTPUT_JSON = "/validation/validation-output.json";
+    private static final String TRIPLE_DOT_IN_KEY = "{\"object...array\":false}";
+    private static final String DOT_IN_KEY = "{\"object.array\":false}";
+    private static final String ARRAY = "[1,2,3]";
+    private static final String DOT_IN_KEY_OUT = "{\"object.array\":false,\"$_yippee-schema-violation\":"
+            + "[{\"path\":\"$.object.array\",\"message\":\"$.object.array: boolean found, number expected\"}]}";
+
+    private static Stream<Arguments> logMessageProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(Set.of(mock(ValidationMessage.class))))
+                .add(Arguments.of(Set.of()))
+                .build();
+    }
+
+    private static Stream<Arguments> jsonProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(json(INPUT_JSON), json(OUTPUT_JSON), json(TEST_SCHEMA_JSON)))
+                .add(Arguments.of(TRIPLE_DOT_IN_KEY, TRIPLE_DOT_IN_KEY, json(TEST_SCHEMA_JSON)))
+                .add(Arguments.of(DOT_IN_KEY, DOT_IN_KEY_OUT, json(TEST_SCHEMA_JSON)))
+                .add(Arguments.of(ARRAY, ARRAY, json(TEST_SCHEMA_INTEGER_JSON)))
+                .build();
+    }
+
+    private static String json(final String jsonName) {
+        try {
+            return IOUtils.resourceToString(jsonName, StandardCharsets.UTF_8);
+        } catch (final IOException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("logMessageProvider")
+    @NullSource
+    void testLogOnlyAcceptShouldGetTheValidationMessages(final Set<ValidationMessage> validationMessages) {
+        //given
+        final ViolationStrategy underTest = ViolationStrategy.LOG_ONLY;
+        final DocumentContext documentContext = mock(DocumentContext.class);
+
+        //when
+        underTest.accept(documentContext, validationMessages);
+
+        //then
+        verifyNoInteractions(documentContext);
+        //noinspection ConstantConditions
+        if (validationMessages != null) {
+            for (final ValidationMessage m : validationMessages) {
+                verify(m).getMessage();
+                verifyNoMoreInteractions(m);
+            }
+        }
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("logMessageProvider")
+    @NullSource
+    void testIgnoreAcceptShouldIgnoreMessages(final Set<ValidationMessage> validationMessages) {
+        //given
+        final ViolationStrategy underTest = ViolationStrategy.IGNORE;
+        final DocumentContext documentContext = mock(DocumentContext.class);
+
+        //when
+        underTest.accept(documentContext, validationMessages);
+
+        //then
+        verifyNoInteractions(documentContext);
+        //noinspection ConstantConditions
+        if (validationMessages != null) {
+            for (final ValidationMessage m : validationMessages) {
+                verifyNoInteractions(m);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void testCommentAcceptShouldReturnIfEmptySetProvided(final Set<ValidationMessage> validationMessages) {
+        //given
+        final ViolationStrategy underTest = ViolationStrategy.COMMENT_JSON;
+        final DocumentContext documentContext = mock(DocumentContext.class);
+
+        //when
+        underTest.accept(documentContext, validationMessages);
+
+        //then
+        verifyNoInteractions(documentContext);
+    }
+
+    @ParameterizedTest
+    @MethodSource("jsonProvider")
+    void testCommentAcceptShouldAddExtraNodesIntoJson(final String jsonString,
+                                                      final String expectedJson,
+                                                      final String schema) throws IOException {
+        //given
+        ViolationStrategy underTest = ViolationStrategy.COMMENT_JSON;
+        final ObjectMapper objectMapper = objectMapper();
+        final JsonNode rootNode = objectMapper.readTree(jsonString);
+        JsonSchemaFactory factory = JsonSchemaFactory
+                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
+                .objectMapper(objectMapper)
+                .build();
+        final JsonSchema jsonSchema = factory.getSchema(schema);
+        final Set<ValidationMessage> validationMessages = jsonSchema.validate(rootNode, rootNode, ViolationStrategy.ROOT_NODE);
+        final DocumentContext documentContext = JsonPath.parse(jsonString, Configuration.builder()
+                .jsonProvider(new JacksonJsonProvider(objectMapper))
+                .mappingProvider(new JacksonMappingProvider(objectMapper))
+                .build());
+
+        //when
+        underTest.accept(documentContext, validationMessages);
+
+        //then
+        final String actualJson = documentContext.jsonString();
+        final JsonNode actual = objectMapper.readTree(actualJson);
+        final JsonNode expected = objectMapper.readTree(expectedJson);
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        final SerializationConfig serializationConfig = objectMapper.getSerializationConfig()
+                .withoutFeatures(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        objectMapper.setConfig(serializationConfig);
+        final DeserializationConfig deserializationConfig = objectMapper.getDeserializationConfig()
+                .with(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                .with(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS);
+        objectMapper.setConfig(deserializationConfig);
+        return objectMapper;
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/supplier/FileContentSupplierTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/supplier/FileContentSupplierTest.java
@@ -1,0 +1,63 @@
+package com.github.nagyesta.yippeekijson.core.supplier;
+
+import com.github.nagyesta.yippeekijson.core.exception.AbortTransformationException;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+class FileContentSupplierTest {
+
+    private static final String VALIDATION_INPUT_JSON = "/validation/validation-input.json";
+    private static final String EXAMPLE_JSON = "/json/example.json";
+
+    @ParameterizedTest
+    @ValueSource(strings = {EXAMPLE_JSON, VALIDATION_INPUT_JSON})
+    void testGetShouldReturnTheStaticString(final String input) throws IOException {
+        //given
+        final File file = new File(this.getClass().getResource(input).getFile());
+        String expected = IOUtils.resourceToString(input, StandardCharsets.UTF_8);
+        final FileContentSupplier underTest = new FileContentSupplier(file.getAbsolutePath(), null);
+
+        //when
+        final String actual = underTest.get();
+
+        //then
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    void testGetShouldThrowAbortExceptionWhenSourceSupplierFails() {
+        //given
+        final FileContentSupplier underTest = new FileContentSupplier(StringUtils.EMPTY, StandardCharsets.UTF_8.name());
+
+        //when + then exception
+        Assertions.assertThrows(AbortTransformationException.class, underTest::get);
+    }
+
+    @Test
+    void testConstructorShouldNotAllowNulls() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new FileContentSupplier(null, null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {VALIDATION_INPUT_JSON, EXAMPLE_JSON})
+    void testToStringShouldContainClassNameAndKey(final String path) {
+        //given
+        final FileContentSupplier underTest = new FileContentSupplier(path, StandardCharsets.UTF_8.name());
+
+        //when
+        final String actual = underTest.toString();
+
+        //then
+        Assertions.assertTrue(actual.contains(FileContentSupplier.class.getSimpleName()));
+        Assertions.assertTrue(actual.contains(path));
+        Assertions.assertTrue(actual.contains(StandardCharsets.UTF_8.name()));
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/supplier/HttpResourceContentSupplierTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/supplier/HttpResourceContentSupplierTest.java
@@ -1,0 +1,68 @@
+package com.github.nagyesta.yippeekijson.core.supplier;
+
+import com.github.nagyesta.yippeekijson.core.http.HttpClient;
+import com.github.nagyesta.yippeekijson.core.http.HttpRequestContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class HttpResourceContentSupplierTest {
+    private static final String VALIDATION_INPUT_JSON = "http://localhost/validation/validation-input.json";
+    private static final String EXAMPLE_JSON = "http://localhost/json/example.json";
+
+    private static Stream<Arguments> nullProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(null, null))
+                .add(Arguments.of(EXAMPLE_JSON, null))
+                .add(Arguments.of(null, mock(HttpClient.class)))
+                .build();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {EXAMPLE_JSON, VALIDATION_INPUT_JSON})
+    void testGetShouldReturnTheStaticString(final String uri) {
+        //given
+        final HttpClient httpClient = mock(HttpClient.class);
+        when(httpClient.fetch(any(HttpRequestContext.class))).thenReturn(uri);
+        final HttpResourceContentSupplier underTest = new HttpResourceContentSupplier(
+                uri, null, null, StandardCharsets.UTF_8.name(), httpClient);
+
+        //when
+        final String actual = underTest.get();
+
+        //then
+        Assertions.assertEquals(uri, actual);
+        verify(httpClient).fetch(argThat(argument -> argument.getUri().equals(uri)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullProvider")
+    void testConstructorShouldNotAllowNulls(final String uri, final HttpClient httpClient) {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new HttpResourceContentSupplier(uri, null, null, StandardCharsets.UTF_8.name(), httpClient));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {VALIDATION_INPUT_JSON, EXAMPLE_JSON})
+    void testToStringShouldContainClassNameAndKey(final String uri) {
+        //given
+        final HttpResourceContentSupplier underTest = new HttpResourceContentSupplier(
+                uri, null, null, StandardCharsets.UTF_8.name(), mock(HttpClient.class));
+
+        //when
+        final String actual = underTest.toString();
+
+        //then
+        Assertions.assertTrue(actual.contains(HttpResourceContentSupplier.class.getSimpleName()));
+        Assertions.assertTrue(actual.contains(uri));
+        Assertions.assertTrue(actual.contains(StandardCharsets.UTF_8.name()));
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/supplier/JsonSchemaSupplierTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/supplier/JsonSchemaSupplierTest.java
@@ -1,0 +1,110 @@
+package com.github.nagyesta.yippeekijson.core.supplier;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.nagyesta.yippeekijson.core.config.parser.FunctionRegistry;
+import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
+import com.github.nagyesta.yippeekijson.core.config.parser.impl.JsonMapperImpl;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
+import com.github.nagyesta.yippeekijson.core.exception.AbortTransformationException;
+import com.networknt.schema.JsonSchema;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonSchemaSupplierTest {
+
+    private static final String EMPTY_JSON = "{}";
+    private static final String TEST_SCHEMA_JSON = "/validation/test-schema.json";
+    private static final String PROPERTIES = "properties";
+    private static final String OBJECT = "object";
+    private static final String ARRAY = "array";
+    private static final String OBJECT_ARRAY = "object.array";
+    private static final String OBJECT_DOTS_ARRAY = "object...array";
+
+    private static Stream<Arguments> nullProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(null, null, null))
+                .add(Arguments.of(Map.of(), null, null))
+                .add(Arguments.of(null, mock(JsonMapper.class), null))
+                .add(Arguments.of(null, null, mock(FunctionRegistry.class)))
+                .add(Arguments.of(Map.of(), mock(JsonMapper.class), null))
+                .add(Arguments.of(Map.of(), null, mock(FunctionRegistry.class)))
+                .add(Arguments.of(null, mock(JsonMapper.class), mock(FunctionRegistry.class)))
+                .build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullProvider")
+    void testConstructorShouldNotAllowNulls(final Map<String, RawConfigParam> map,
+                                            final JsonMapper jsonMapper,
+                                            final FunctionRegistry functionRegistry) {
+        //given
+
+        //when + then exception
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new JsonSchemaSupplier(map, jsonMapper, functionRegistry));
+    }
+
+    @Test
+    void testGetShouldThrowAbortExceptionWhenSourceSupplierFails() {
+        //given
+        JsonMapper jsonMapper = new JsonMapperImpl();
+        FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        when(functionRegistry.lookupSupplier(anyMap())).thenReturn(() -> {
+            throw new IllegalArgumentException();
+        });
+        final JsonSchemaSupplier underTest = new JsonSchemaSupplier(Map.of(), jsonMapper, functionRegistry);
+
+        //when + then exception
+        Assertions.assertThrows(AbortTransformationException.class, underTest::get);
+    }
+
+    @Test
+    void testGetShouldReturnSchemaWhenSourceSupplierReturnsValidInput() throws IOException {
+        //given
+        String schemaSource = IOUtils.resourceToString(TEST_SCHEMA_JSON, StandardCharsets.UTF_8);
+        JsonMapper jsonMapper = new JsonMapperImpl();
+        FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        when(functionRegistry.lookupSupplier(anyMap())).thenReturn(() -> schemaSource);
+        final JsonSchemaSupplier underTest = new JsonSchemaSupplier(Map.of(), jsonMapper, functionRegistry);
+
+        //when
+        final JsonSchema actual = underTest.get();
+
+        //then
+        Assertions.assertNotNull(actual);
+        Assertions.assertTrue(actual.getSchemaNode().hasNonNull(PROPERTIES));
+        final JsonNode properties = actual.getSchemaNode().get(PROPERTIES);
+        Assertions.assertTrue(properties.hasNonNull(OBJECT));
+        Assertions.assertTrue(properties.hasNonNull(ARRAY));
+        Assertions.assertTrue(properties.hasNonNull(OBJECT_ARRAY));
+        Assertions.assertTrue(properties.hasNonNull(OBJECT_DOTS_ARRAY));
+    }
+
+    @Test
+    void testToStringShouldContainClassName() {
+        //given
+        JsonMapper jsonMapper = new JsonMapperImpl();
+        FunctionRegistry functionRegistry = mock(FunctionRegistry.class);
+        when(functionRegistry.lookupSupplier(anyMap())).thenReturn(() -> EMPTY_JSON);
+        final JsonSchemaSupplier underTest = new JsonSchemaSupplier(Map.of(), jsonMapper, functionRegistry);
+
+        //when
+        final String actual = underTest.toString();
+
+        //then
+        Assertions.assertTrue(actual.contains(JsonSchemaSupplier.class.getSimpleName()));
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/supplier/SchemaStoreSchemaContentSupplierTest.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/supplier/SchemaStoreSchemaContentSupplierTest.java
@@ -1,0 +1,168 @@
+package com.github.nagyesta.yippeekijson.core.supplier;
+
+import com.github.nagyesta.yippeekijson.core.config.entities.SchemaStoreConfig;
+import com.github.nagyesta.yippeekijson.core.config.parser.JsonMapper;
+import com.github.nagyesta.yippeekijson.core.config.parser.impl.JsonMapperImpl;
+import com.github.nagyesta.yippeekijson.core.http.HttpClient;
+import com.github.nagyesta.yippeekijson.core.http.HttpRequestContext;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SchemaStoreSchemaContentSupplierTest {
+
+    static final String YIPPEE_SCHEMA_NAME = "Yippee-Ki-JSON configuration YML";
+    static final String CATALOG_URI = "http://localhost:41562/catalog.json";
+    static final String YIPPR_SCHEMA_URI = "http://localhost:41562/nagyesta/yippee-ki-json/main/schema/yippee-ki-json_config_schema.json";
+    private static final String SCHEMASTORE_CATALOG_JSON = "/validation/schemastore-catalog.json";
+    private static final String YIPPEE_KI_JSON_CONFIG_SCHEMA_JSON = "/yippee-ki-json_config_schema.json";
+    private static final String SCHEMA_ARRAY_PATH = "$.schemas[*]";
+    private static final String NAME = "name";
+    private static final String URL = "url";
+    private static final String UNKNOWN = "unknown";
+
+    private static Stream<Arguments> nullProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(null, null, null, null))
+                .add(Arguments.of(YIPPEE_SCHEMA_NAME, null, null, null))
+                .add(Arguments.of(null, mock(HttpClient.class), null, null))
+                .add(Arguments.of(null, null, mock(JsonMapper.class), null))
+                .add(Arguments.of(null, null, null, SchemaStoreConfig.builder().build()))
+                .add(Arguments.of(YIPPEE_SCHEMA_NAME, mock(HttpClient.class), mock(JsonMapper.class), null))
+                .add(Arguments.of(YIPPEE_SCHEMA_NAME, mock(HttpClient.class), null, SchemaStoreConfig.builder().build()))
+                .add(Arguments.of(YIPPEE_SCHEMA_NAME, null, mock(JsonMapper.class), SchemaStoreConfig.builder().build()))
+                .add(Arguments.of(null, mock(HttpClient.class), mock(JsonMapper.class), SchemaStoreConfig.builder().build()))
+                .build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullProvider")
+    void testConstructorShouldNotAllowNulls(final String schemaName,
+                                            final HttpClient httpClient,
+                                            final JsonMapper jsonMapper,
+                                            final SchemaStoreConfig schemaStoreConfig) {
+        //given
+
+        //when + then exception
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new SchemaStoreSchemaContentSupplier(schemaName, httpClient, jsonMapper, schemaStoreConfig));
+    }
+
+    @Test
+    void testGetShouldReturnSchemaWhenCalledWithKnownSchemaName() throws IOException {
+        //given
+        String storeCatalogJson = IOUtils.resourceToString(SCHEMASTORE_CATALOG_JSON, StandardCharsets.UTF_8);
+        String schemaJson = IOUtils.resourceToString(YIPPEE_KI_JSON_CONFIG_SCHEMA_JSON, StandardCharsets.UTF_8);
+        final HttpClient httpClient = mock(HttpClient.class);
+        whenFetchedReturnJson(storeCatalogJson, httpClient, CATALOG_URI);
+        whenFetchedReturnJson(schemaJson, httpClient, YIPPR_SCHEMA_URI);
+        final JsonMapper jsonMapper = new JsonMapperImpl();
+        final SchemaStoreConfig schemaStoreConfig = schemaStoreConfig();
+        final SchemaStoreSchemaContentSupplier underTest = new SchemaStoreSchemaContentSupplier(
+                YIPPEE_SCHEMA_NAME, httpClient, jsonMapper, schemaStoreConfig);
+
+        //when
+        final String actual = underTest.get();
+
+        //then
+        Assertions.assertEquals(schemaJson, actual);
+    }
+
+    @Test
+    void testGetShouldThrowExceptionWhenCalledWithUnknownSchemaName() throws IOException {
+        //given
+        String storeCatalogJson = IOUtils.resourceToString(SCHEMASTORE_CATALOG_JSON, StandardCharsets.UTF_8);
+        final HttpClient httpClient = mock(HttpClient.class);
+        whenFetchedReturnJson(storeCatalogJson, httpClient, CATALOG_URI);
+        final JsonMapper jsonMapper = new JsonMapperImpl();
+        final SchemaStoreConfig schemaStoreConfig = schemaStoreConfig();
+        final SchemaStoreSchemaContentSupplier underTest = new SchemaStoreSchemaContentSupplier(
+                UNKNOWN, httpClient, jsonMapper, schemaStoreConfig);
+
+        //when + then exception
+        Assertions.assertThrows(IllegalArgumentException.class, underTest::get);
+    }
+
+    @Test
+    void testGetShouldThrowExceptionWhenCalledWithoutAnyKnownSchemas() throws IOException {
+        //given
+        String storeCatalogJson = IOUtils.resourceToString(SCHEMASTORE_CATALOG_JSON, StandardCharsets.UTF_8);
+        final HttpClient httpClient = mock(HttpClient.class);
+        whenFetchedReturnJson(storeCatalogJson, httpClient, CATALOG_URI);
+        final JsonMapper jsonMapper = new JsonMapperImpl();
+        final SchemaStoreConfig schemaStoreConfig = SchemaStoreConfig.builder()
+                .catalogUri(CATALOG_URI)
+                .schemaArrayPath(SCHEMA_ARRAY_PATH)
+                .mappingNameKey(UNKNOWN)
+                .mappingUrlKey(URL)
+                .build();
+        final SchemaStoreSchemaContentSupplier underTest = new SchemaStoreSchemaContentSupplier(
+                YIPPEE_SCHEMA_NAME, httpClient, jsonMapper, schemaStoreConfig);
+
+        //when + then exception
+        Assertions.assertThrows(IllegalArgumentException.class, underTest::get);
+    }
+
+    @Test
+    void testGetShouldThrowExceptionWhenCatalogIsNotParsable() {
+        //given
+        final HttpClient httpClient = mock(HttpClient.class);
+        whenFetchedReturnJson(UNKNOWN, httpClient, CATALOG_URI);
+        final JsonMapper jsonMapper = new JsonMapperImpl();
+        final SchemaStoreConfig schemaStoreConfig = SchemaStoreConfig.builder()
+                .catalogUri(CATALOG_URI)
+                .schemaArrayPath(SCHEMA_ARRAY_PATH)
+                .mappingNameKey(UNKNOWN)
+                .mappingUrlKey(URL)
+                .build();
+        final SchemaStoreSchemaContentSupplier underTest = new SchemaStoreSchemaContentSupplier(
+                YIPPEE_SCHEMA_NAME, httpClient, jsonMapper, schemaStoreConfig);
+
+        //when + then exception
+        Assertions.assertThrows(IllegalArgumentException.class, underTest::get);
+    }
+
+    @Test
+    void testToStringShouldContainClassName() {
+        //given
+        final HttpClient httpClient = mock(HttpClient.class);
+        final JsonMapper jsonMapper = new JsonMapperImpl();
+        final SchemaStoreConfig schemaStoreConfig = SchemaStoreConfig.builder().build();
+        final SchemaStoreSchemaContentSupplier underTest = new SchemaStoreSchemaContentSupplier(
+                YIPPEE_SCHEMA_NAME, httpClient, jsonMapper, schemaStoreConfig);
+
+        //when
+        final String actual = underTest.toString();
+
+        //then
+        Assertions.assertTrue(actual.contains(SchemaStoreSchemaContentSupplier.class.getSimpleName()));
+        Assertions.assertTrue(actual.contains(YIPPEE_SCHEMA_NAME));
+    }
+
+    private void whenFetchedReturnJson(final String storeCatalogJson, final HttpClient httpClient, final String catalogUri) {
+        HttpRequestContext catalogRequestContext = HttpRequestContext.builder()
+                .uri(catalogUri)
+                .build();
+        when(httpClient.fetch(eq(catalogRequestContext))).thenReturn(storeCatalogJson);
+    }
+
+    private SchemaStoreConfig schemaStoreConfig() {
+        return SchemaStoreConfig.builder()
+                .catalogUri(CATALOG_URI)
+                .schemaArrayPath(SCHEMA_ARRAY_PATH)
+                .mappingNameKey(NAME)
+                .mappingUrlKey(URL)
+                .build();
+    }
+}

--- a/src/test/java/com/github/nagyesta/yippeekijson/core/test/params/ParamAnnotationHolder.java
+++ b/src/test/java/com/github/nagyesta/yippeekijson/core/test/params/ParamAnnotationHolder.java
@@ -1,0 +1,114 @@
+package com.github.nagyesta.yippeekijson.core.test.params;
+
+import com.github.nagyesta.yippeekijson.core.annotation.EmbedParam;
+import com.github.nagyesta.yippeekijson.core.annotation.MapParam;
+import com.github.nagyesta.yippeekijson.core.annotation.MethodParam;
+import com.github.nagyesta.yippeekijson.core.annotation.ValueParam;
+import com.github.nagyesta.yippeekijson.core.config.parser.impl.ParameterContext;
+import com.github.nagyesta.yippeekijson.core.config.parser.raw.RawConfigParam;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.lang.Nullable;
+
+import javax.inject.Named;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+@SuppressWarnings("checkstyle:JavadocVariable")
+public abstract class ParamAnnotationHolder {
+    public static final String METHOD_PARAM = "methodParam";
+    public static final String VALUE_PARAM = "valueParam";
+    public static final String MAP_PARAM = "mapParam";
+    public static final String EMBED_PARAM = "embedParam";
+    public static final String METHOD_PARAM_ALL_FALSE = "allFalse";
+    public static final String METHOD_PARAM_PARAM_MAP_TRUE = "paramMapTrue";
+    public static final String METHOD_PARAM_PARAM_MAP_FALSE = "paramMapFalse";
+    public static final String METHOD_PARAM_REPEAT_FALSE = "repeatFalse";
+    public static final String METHOD_PARAM_REPEAT_TRUE = "repeatTrue";
+    public static final String METHOD_PARAM_STRING_MAP_TRUE = "stringMapTrue";
+    public static final String METHOD_PARAM_ALL_TRUE = "allTrue";
+    public static final String PARAM_DIFFERENT_NAME = "differentName";
+    public static final String PARAM_DIFFERENT_NAME_EXPECTED = "name";
+    public static final String PARAM_SAME_NAME = "sameName";
+    public static final String PARAM_JAVAX_NULLABLE = "javaxNullable";
+    public static final String PARAM_SPRING_NULLABLE = "springNullable";
+    public static final String PARAM_SPRING_NULLABLE_EXPECTED = "nullable";
+    public static final String PARAM_NAMED_LIST = "namedList";
+    public static final String PARAM_NAMED_LIST_EXPECTED = "list";
+    private static final String VALUE = "value";
+
+    private ParamAnnotationHolder() {
+        throw new IllegalStateException("Utility.");
+    }
+
+    private static void valueParam(@ValueParam("name") final String differentName,
+                                   @ValueParam("sameName") final String sameName,
+                                   @ValueParam @javax.annotation.Nullable final String javaxNullable,
+                                   @ValueParam @Qualifier("nullable") @Nullable final String springNullable,
+                                   @ValueParam @Named("list") final Collection<String> namedList) {
+    }
+
+    private static void mapParam(@MapParam("name") final Map<String, String> differentName,
+                                 @MapParam("sameName") final Map<String, String> sameName,
+                                 @MapParam @javax.annotation.Nullable final Map<String, String> javaxNullable,
+                                 @MapParam @Qualifier("nullable") @Nullable final Map<String, String> springNullable,
+                                 @MapParam @Named("list") final Collection<Map<String, String>> namedList) {
+    }
+
+    private static void embedParam(@EmbedParam("name") final Map<String, RawConfigParam> differentName,
+                                   @EmbedParam("sameName") final Map<String, RawConfigParam> sameName,
+                                   @EmbedParam @javax.annotation.Nullable final Map<String, RawConfigParam> javaxNullable,
+                                   @EmbedParam @Qualifier("nullable") @Nullable final Map<String, RawConfigParam> springNullable,
+                                   @EmbedParam @Named("list") final Collection<Map<String, RawConfigParam>> namedList) {
+    }
+
+    @SuppressWarnings({"deprecation", "DefaultAnnotationParam"})
+    static void methodParam(@MethodParam(value = VALUE, stringMap = false, paramMap = false, repeat = false)
+                            @NotNull final Object allFalse,
+                            @MethodParam(value = VALUE, stringMap = false, paramMap = false, repeat = true)
+                            @NotNull final Object repeatTrue,
+                            @MethodParam(value = VALUE, stringMap = false, paramMap = true, repeat = false)
+                            @NotNull final Object paramMapTrue,
+                            @MethodParam(value = VALUE, stringMap = true, paramMap = false, repeat = true)
+                            @NotNull final Object paramMapFalse,
+                            @MethodParam(value = VALUE, stringMap = true, paramMap = false, repeat = false)
+                            @NotNull final Object stringMapTrue,
+                            @MethodParam(value = VALUE, stringMap = true, paramMap = true, repeat = false)
+                            @NotNull final Object repeatFalse,
+                            @MethodParam(value = VALUE, stringMap = true, paramMap = true, repeat = true)
+                            @NotNull final Object allTrue
+    ) {
+
+    }
+
+
+    public static ParameterContext getParamContextForUseCase(final ParameterContext.UseCase useCase, final String name) {
+        switch (useCase) {
+            case VALUE:
+                return getParameterContextFor(VALUE_PARAM, name);
+            case MAP:
+                return getParameterContextFor(MAP_PARAM, name);
+            case EMBEDDED:
+            default:
+                return getParameterContextFor(EMBED_PARAM, name);
+        }
+    }
+
+    public static ParameterContext getMethodParamContext(final String name) {
+        return getParameterContextFor(METHOD_PARAM, name);
+    }
+
+    @NotNull
+    private static ParameterContext getParameterContextFor(final String methodName, final String paramName) {
+        return Arrays.stream(ParamAnnotationHolder.class.getDeclaredMethods())
+                .filter(method -> methodName.equals(method.getName()))
+                .map(Method::getParameters)
+                .flatMap(Arrays::stream)
+                .filter(param -> paramName.equals(param.getName()))
+                .filter(ParameterContext::supports)
+                .map(ParameterContext::forParameter)
+                .findFirst().orElseThrow(IllegalArgumentException::new);
+    }
+}

--- a/src/test/resources/validation/schemastore-catalog.json
+++ b/src/test/resources/validation/schemastore-catalog.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/schema-catalog",
+  "version": 1.0,
+  "schemas": [
+    {
+      "name": "Yippee-Ki-JSON configuration YML",
+      "description": "Action and rule configuration descriptor for Yippee-Ki-JSON transformations.",
+      "fileMatch": [
+        "**/yippee-*.yml",
+        "**/*.yippee.yml"
+      ],
+      "url": "http://localhost:41562/nagyesta/yippee-ki-json/main/schema/yippee-ki-json_config_schema.json",
+      "versions": {
+        "1.1.2": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/v1.1.2/schema/yippee-ki-json_config_schema.json",
+        "latest": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/main/schema/yippee-ki-json_config_schema.json"
+      }
+    }
+  ]
+}

--- a/src/test/resources/validation/test-schema-integer.json
+++ b/src/test/resources/validation/test-schema-integer.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "integer"
+}

--- a/src/test/resources/validation/test-schema.json
+++ b/src/test/resources/validation/test-schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "properties": {
+    "object": {
+      "type": "object",
+      "properties": {
+        "object-inner": {
+          "type": "object"
+        },
+        "array-inner": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "required": [
+        "array-inner",
+        "object-inner"
+      ],
+      "additionalProperties": false
+    },
+    "array": {
+      "items": {
+        "type": "integer"
+      },
+      "minItems": 2
+    },
+    "object.array": {
+      "type": "number"
+    },
+    "object...array": {
+      "type": "number"
+    },
+    "array-inner": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/test/resources/validation/validation-input.json
+++ b/src/test/resources/validation/validation-input.json
@@ -1,0 +1,14 @@
+{
+  "object": {
+    "array-inner": [
+      1
+    ]
+  },
+  "array": [
+    {
+      "integer": 1,
+      "float": 2.0,
+      "boolean": true
+    }
+  ]
+}

--- a/src/test/resources/validation/validation-output-childnodes.json
+++ b/src/test/resources/validation/validation-output-childnodes.json
@@ -1,0 +1,20 @@
+{
+  "object": {
+    "array": [
+      1
+    ],
+    "$_yippee-schema-violation": [
+      {
+        "path": "$['object'].array",
+        "message": "$['object'].array: there must be a minimum of 2 items in the array"
+      }
+    ]
+  },
+  "array": [
+    {
+      "integer": 1,
+      "float": 2.0,
+      "boolean": true
+    }
+  ]
+}

--- a/src/test/resources/validation/validation-output.json
+++ b/src/test/resources/validation/validation-output.json
@@ -1,0 +1,36 @@
+{
+  "object": {
+    "array-inner": [
+      1
+    ],
+    "$_yippee-schema-violation": [
+      {
+        "path": "$.object",
+        "message": "$.object.object-inner: is missing but it is required"
+      },
+      {
+        "path": "$.object.array-inner[0]",
+        "message": "$.object.array-inner[0]: integer found, object expected"
+      }
+    ]
+  },
+  "array": [
+    {
+      "integer": 1,
+      "float": 2.0,
+      "boolean": true,
+      "$_yippee-schema-violation": [
+        {
+          "path": "$.array[0]",
+          "message": "$.array[0]: object found, integer expected"
+        }
+      ]
+    }
+  ],
+  "$_yippee-schema-violation": [
+    {
+      "path": "$.array",
+      "message": "$.array: there must be a minimum of 2 items in the array"
+    }
+  ]
+}

--- a/src/test/resources/yaml/all-rules.yml
+++ b/src/test/resources/yaml/all-rules.yml
@@ -1,6 +1,37 @@
 actions:
+  - name: "validate"
+    rules:
+      - name: "validate"
+        path: "$"
+        params:
+          onFailure:
+            transformation: SKIP_REST
+            violation: COMMENT_JSON
+          schema:
+            name: "jsonSchema"
+            source:
+              name: "file"
+              path: "build/test-results/systemTest/example.json"
   - name: "demo"
     rules:
+      - name: "add"
+        path: "$..a"
+        params:
+          key:
+            name: "staticString"
+            value: "key"
+          value:
+            name: "converting"
+            stringSource:
+              name: "httpResource"
+              uri: "http://localhost/"
+              httpMethod: "GET"
+              httpHeaders:
+                Accept: "application/json"
+                User-Agent: "Yippee-Ki-JSON"
+              charset: "UTF-8"
+            converter:
+              name: "jsonParse"
       - name: "add"
         path: "$..a"
         params:
@@ -68,6 +99,17 @@ actions:
             replacement: "${lastName}"
           predicate:
             name: "anyString"
+      - name: "replace"
+        path: "$.accounts..name.jsonref"
+        params:
+          stringFunction:
+            name: "httpResourceByUri"
+            uriFunction:
+              name: regex
+              pattern: ^(?<path>[A-Za-z0-9\-\.]+\.json)$
+              replacement: "http://localhost/${path}"
+          predicate:
+            name: "anyString"
       - name: "replaceMap"
         path: "$.accounts..firstName"
         params:
@@ -78,3 +120,41 @@ actions:
             name: "cloneKey"
             from: "source"
             to: "destination"
+      - name: "validate"
+        path: "$"
+        params:
+          schema:
+            name: "jsonSchema"
+            source:
+              name: "file"
+              path: "./schema.json"
+          onFailure:
+            transformation: "SKIP_REST"
+            violation: "COMMENT_JSON"
+      - name: "validate"
+        path: "$"
+        params:
+          schema:
+            name: "jsonSchema"
+            source:
+              name: "schemaStore"
+              schemaName: "Yippee-Ki-JSON configuration YML"
+          onFailure:
+            transformation: "SKIP_REST"
+            violation: "COMMENT_JSON"
+      - name: "validate"
+        path: "$"
+        params:
+          schema:
+            name: "jsonSchema"
+            source:
+              name: "httpResource"
+              uri: "http://localhost/"
+              httpMethod: "GET"
+              httpHeaders:
+                Accept: "application/json"
+                User-Agent: "Yippee-Ki-JSON"
+              charset: "UTF-8"
+          onFailure:
+            transformation: "SKIP_REST"
+            violation: "COMMENT_JSON"


### PR DESCRIPTION
- Switches to Jackson for YML parsing
- Integrates schema validation for config YML
- Changes JsonMapper to expose objectMapper if needed
- Changes JsonTransformerImpl to respect Abort and Skip decisions
- Adds basic HTTP client abstraction layer
- Relaxes Rule and Function parameter restrictions
- Defines Injectable beans available for constructor calls
- Redefines parameter annotations
- Deprecates @MethodParam
- Automated parameter name, type and required status checks
- Http client and Schema Store configurations added
- Documentations updated with new startup param

Rules
- Adds JsonValidationRule

Suppliers/Functions
- Adds File content supplier
- Adds HTTP fetching supplier
- Adds Schema Store fetching supplier
- Adds Converting supplier
- Adds JSON Parse function
- Adds HTTP fetching functions

Schema
- Refines JSON schema to allow more relaxed key names
- Adds new suppliers to YAML Schema
- Adds new functions to YAML Schema
- Adds new validation rule to YAML Schema

Gradle
- Gradle fixes to use relative paths properly
- New system test step aiming at YML and JSON validation

Bugfix
- Fixes YML parsing issue failing if non-String params are used
[minor]